### PR TITLE
Add missing interrupt definitions so that generated pac's can be used in an RTIC application

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -102,12 +102,14 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
         #peripherals
     ));
 
-    let bits = util::unsuffixed(u64::from(d.nvic_priority_bits));
-    out.extend(quote! {
-        /// Number available in the NVIC for configuring priority
-        #[cfg(feature = "rt")]
-        pub const NVIC_PRIO_BITS: u8 = #bits;
-    });
+    if let Some(nvic_priority_bits) = d.nvic_priority_bits {
+        let bits = util::unsuffixed(u64::from(nvic_priority_bits));
+        out.extend(quote! {
+            /// Number available in the NVIC for configuring priority
+            #[cfg(feature = "rt")]
+            pub const NVIC_PRIO_BITS: u8 = #bits;
+        });
+    }
 
     out.extend(quote! {
         #[cfg(feature = "rt")]

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -67,16 +67,12 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
             });
         }
     }
-
     let n = util::unsuffixed(pos as u64);
     out.extend(quote!(
         #[derive(Copy, Clone, Debug, PartialEq, Eq)]
         pub enum Interrupt {
             #interrupts
         }
-
-        pub use cortex_m_rt::interrupt;
-        pub use Interrupt as interrupt;
 
         unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
             #[inline(always)]
@@ -106,16 +102,19 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
         #peripherals
     ));
 
-    /*
-    if let Some(cpu) = d.cpu.as_ref() {
-        let bits = util::unsuffixed(u64::from(cpu.nvic_priority_bits));
+    let bits = util::unsuffixed(u64::from(d.nvic_priority_bits));
+    out.extend(quote! {
+        /// Number available in the NVIC for configuring priority
+        #[cfg(feature = "rt")]
+        pub const NVIC_PRIO_BITS: u8 = #bits;
+    });
 
-        out.extend(quote! {
-            ///Number available in the NVIC for configuring priority
-            pub const NVIC_PRIO_BITS: u8 = #bits;
-        });
-    }
-     */
+    out.extend(quote! {
+        #[cfg(feature = "rt")]
+        pub use cortex_m_rt::interrupt;
+        #[cfg(feature = "rt")]
+        pub use Interrupt as interrupt;
+    });
 
     Ok(out)
 }

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -75,6 +75,9 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
             #interrupts
         }
 
+        pub use cortex_m_rt::interrupt;
+        pub use Interrupt as interrupt;
+
         unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
             #[inline(always)]
             fn number(self) -> u16 {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -31,7 +31,8 @@ impl IR {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Device {
-    pub nvic_priority_bits: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nvic_priority_bits: Option<u8>,
     pub peripherals: Vec<Peripheral>,
     pub interrupts: Vec<Interrupt>,
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -31,6 +31,7 @@ impl IR {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Device {
+    pub nvic_priority_bits: u8,
     pub peripherals: Vec<Peripheral>,
     pub interrupts: Vec<Interrupt>,
 }

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -264,6 +264,11 @@ pub fn convert_svd(svd: &svd::Device) -> anyhow::Result<IR> {
     let mut ir = IR::new();
 
     let mut device = Device {
+        nvic_priority_bits: if let Some(cpu) = &svd.cpu {
+            cpu.nvic_priority_bits as u8
+        } else {
+            0
+        },
         peripherals: vec![],
         interrupts: vec![],
     };

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -264,11 +264,7 @@ pub fn convert_svd(svd: &svd::Device) -> anyhow::Result<IR> {
     let mut ir = IR::new();
 
     let mut device = Device {
-        nvic_priority_bits: if let Some(cpu) = &svd.cpu {
-            cpu.nvic_priority_bits as u8
-        } else {
-            0
-        },
+        nvic_priority_bits: svd.cpu.as_ref().map(|cpu| cpu.nvic_priority_bits as u8),
         peripherals: vec![],
         interrupts: vec![],
     };


### PR DESCRIPTION
The intention is to regenerate `stm32-metapac` crate,  to include interrupt definitions, similar to those in peripheral access crates that are based on `svd2rust`, so that the `embassy-stm32` HAL can be used in an [RTIC](https://github.com/rtic-rs/rtic) application.

With current functionality, it is possible to do this in an RTIC app - thanks to @korken89 and @MathiasKoch for the pointers :
```rust
pub mod pac {
    pub const NVIC_PRIO_BITS: u8 = 2;
    pub use cortex_m_rt::interrupt;
    pub use embassy_stm32::pac::Interrupt as interrupt;
    pub use embassy_stm32::pac::*;
}

#[app(device = crate::pac, peripherals = false)]
```

The intention would be to reduce it to:
```rust
#[app(device = embassy_stm32, peripherals = false)]
```

## WIP plan of attack: 
[x] Expose `interrupt` attribute macro, `Interrupt` enum. (This was the 'easy' part, and I am using it to validate that all the [patch.crates-io] paths work in my tests.). Using this PR to update the `stm32-metapac`, this reduces the required code from above to: 
```rust
  pub mod pac {
      pub const NVIC_PRIO_BITS: u8 = 2;
      // pub use cortex_m_rt::interrupt;
      // pub use embassy_stm32::pac::Interrupt as interrupt;
      pub use embassy_stm32::pac::*;
  }
  
  #[app(device = crate::pac, peripherals = false)]
```

[x] Expose `NVIC_PRIO_BITS` in `chiptool`

[x] Expose `NVIC_PRIO_BITS` in `stm32-metapac` [Unmerged PR](https://github.com/embassy-rs/stm32-data/pull/173)

[x] Test with new generated `stm32-metapac`. Can successfully build and run an RTIC v2 app, using the following:
```rust
#[app(device = embassy_stm32::pac, peripherals = false, dispatchers = [FDCAN1_IT0, FDCAN2_IT0])]
```
**TBD** : @Dirbaio , and @korken89, the `device = <crate>` still requires appending the `::pac` qualifier. Is it necessary to modify the `embassy_stm32` crate to eliminate this, or is this an acceptable user experience?