### PR TITLE
add `keep_desc` option to `DeleteEnums` and `MergeEnums` transform

### DIFF
--- a/src/transform/delete_enums.rs
+++ b/src/transform/delete_enums.rs
@@ -11,10 +11,16 @@ pub struct DeleteEnums {
     pub bit_size: Option<u32>,
     #[serde(default)]
     pub soft: bool,
+    pub keep_desc: Option<bool>,
 }
 
 impl DeleteEnums {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        if self.keep_desc.unwrap_or(false) {
+            let variant_desc = extract_variant_desc(ir, &self.from, self.bit_size)?;
+            append_variant_desc_to_field(ir, &variant_desc, self.bit_size);
+        }
+
         let re = make_regex(&self.from)?;
 
         let mut ids: HashSet<String> = HashSet::new();

--- a/src/transform/merge_enums.rs
+++ b/src/transform/merge_enums.rs
@@ -13,10 +13,16 @@ pub struct MergeEnums {
     pub check: CheckLevel,
     #[serde(default)]
     pub skip_unmergeable: bool,
+    pub keep_desc: Option<bool>,
 }
 
 impl MergeEnums {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        if self.keep_desc.unwrap_or(false) {
+            let variant_desc = extract_variant_desc(ir, &self.from, None)?;
+            append_variant_desc_to_field(ir, &variant_desc, None);
+        }
+
         let re = make_regex(&self.from)?;
         let groups = match_groups(ir.enums.keys().cloned(), &re, &self.to);
 


### PR DESCRIPTION
concat variant descriptions of a enum, then append to related field description

take a look at embassy-rs/stm32-data#358 for a example