### PR TITLE
Support discontinuous field

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -149,6 +149,40 @@ pub enum BitOffset {
     Regular(u32),
     Cursed(Vec<RangeInclusive<u32>>),
 }
+
+impl BitOffset {
+    fn min_offset(&self) -> u32 {
+        match self {
+            BitOffset::Regular(offset) => *offset,
+            BitOffset::Cursed(range_list) => *range_list[0].start(),
+        }
+    }
+
+    fn max_offset(&self) -> u32 {
+        match self {
+            BitOffset::Regular(offset) => *offset,
+            BitOffset::Cursed(range_list) => *range_list[range_list.len()].end(),
+        }
+    }
+}
+
+// custom bit offset ordering:
+// 1. compare min offset: less is less, greater is greater
+// 2. when min offset is equal, compare max offset: less is less, greater is greater, equal is equal
+impl PartialOrd for BitOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use std::cmp::Ordering;
+
+        let min_order = self.min_offset().cmp(&other.min_offset());
+        let result = match min_order {
+            Ordering::Equal => self.max_offset().cmp(&other.max_offset()),
+            min_order => min_order,
+        };
+
+        Some(result)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Field {
     pub name: String,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -156,14 +156,14 @@ impl BitOffset {
     pub(crate) fn min_offset(&self) -> u32 {
         match self {
             BitOffset::Regular(offset) => *offset,
-            BitOffset::Cursed(range_list) => *range_list[0].start(),
+            BitOffset::Cursed(ranges) => *ranges[0].start(),
         }
     }
 
     pub(crate) fn max_offset(&self) -> u32 {
         match self {
             BitOffset::Regular(offset) => *offset,
-            BitOffset::Cursed(range_list) => *range_list[range_list.len()].end(),
+            BitOffset::Cursed(ranges) => *ranges[ranges.len()].end(),
         }
     }
 
@@ -175,26 +175,24 @@ impl BitOffset {
     }
 }
 
-// custom bit offset ordering:
-// 1. compare min offset: less is less, greater is greater
-// 2. when min offset is equal, compare max offset: less is less, greater is greater, equal is equal
-impl PartialOrd for BitOffset {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+// Custom bit offset ordering:
+// 1. Compare min offset: less is less, greater is greater. If min offset is equal,
+// 2. Compare max offset: less is less, greater is greater, equal is equal
+impl Ord for BitOffset {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         use std::cmp::Ordering;
 
         let min_order = self.min_offset().cmp(&other.min_offset());
-        let result = match min_order {
+        match min_order {
             Ordering::Equal => self.max_offset().cmp(&other.max_offset()),
             min_order => min_order,
-        };
-
-        Some(result)
+        }
     }
 }
 
-impl Ord for BitOffset {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+impl PartialOrd for BitOffset {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -164,6 +164,13 @@ impl BitOffset {
             BitOffset::Cursed(range_list) => *range_list[range_list.len()].end(),
         }
     }
+
+    pub(crate) fn into_ranges(&self, bit_size: u32) -> Vec<RangeInclusive<u32>> {
+        match self {
+            BitOffset::Regular(offset) => vec![(*offset)..=(*offset) + bit_size - 1],
+            BitOffset::Cursed(ranges) => *ranges,
+        }
+    }
 }
 
 // custom bit offset ordering:

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -163,7 +163,7 @@ impl BitOffset {
     pub(crate) fn max_offset(&self) -> u32 {
         match self {
             BitOffset::Regular(offset) => *offset,
-            BitOffset::Cursed(ranges) => *ranges[ranges.len()].end(),
+            BitOffset::Cursed(ranges) => *ranges[ranges.len() - 1].end(),
         }
     }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -2,6 +2,7 @@ use de::MapAccess;
 use serde::{de, de::Visitor, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
+use std::ops::RangeInclusive;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct IR {
@@ -143,12 +144,17 @@ pub struct FieldSet {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BitOffset {
+    Regular(u32),
+    Cursed(Vec<RangeInclusive<u32>>),
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Field {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
-    pub bit_offset: u32,
+    pub bit_offset: BitOffset,
     pub bit_size: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub array: Option<Array>,

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -271,7 +271,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
             let mut field = Field {
                 name: f.name.clone(),
                 description: f.description.clone(),
-                bit_offset: f.bit_range.offset,
+                bit_offset: BitOffset::Regular(f.bit_range.offset),
                 bit_size: f.bit_range.width,
                 array: None,
                 enumm: None,

--- a/src/transform/delete_fieldsets.rs
+++ b/src/transform/delete_fieldsets.rs
@@ -38,10 +38,13 @@ impl DeleteFieldsets {
     }
 }
 
+// Fieldset is useless when
+// 1. it has no Fields, or
+// 2. it has one Fields, which occupied entire Fieldset, and without a enum
 fn is_useless(fs: &FieldSet) -> bool {
     match &fs.fields[..] {
         [] => true,
-        [f] => fs.bit_size == f.bit_size && f.bit_offset == 0 && f.enumm.is_none(),
+        [f] => fs.bit_size == f.bit_size && f.bit_offset.min_offset() == 0 && f.enumm.is_none(),
         _ => false,
     }
 }

--- a/src/transform/make_field_array.rs
+++ b/src/transform/make_field_array.rs
@@ -46,8 +46,8 @@ impl MakeFieldArray {
                     items
                         .iter()
                         .map(|x| {
-                            if let BitOffset::Regular(v) = x.bit_offset {
-                                v
+                            if let BitOffset::Regular(offset) = x.bit_offset {
+                                offset
                             } else {
                                 unreachable!()
                             }

--- a/src/transform/sort.rs
+++ b/src/transform/sort.rs
@@ -11,7 +11,8 @@ impl Sort {
             z.items.sort_by_key(|i| (i.byte_offset, i.name.clone()))
         }
         for z in ir.fieldsets.values_mut() {
-            z.fields.sort_by_key(|i| (i.bit_offset, i.name.clone()))
+            z.fields
+                .sort_by_key(|i| (i.bit_offset.clone(), i.name.clone()))
         }
         for z in ir.enums.values_mut() {
             z.variants.sort_by_key(|i| (i.value, i.name.clone()))

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -89,11 +89,20 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                         "fieldset {} field {}: enum {} does not exist",
                         fsname, f.name, ename
                     ));
-                    continue
+                    continue;
                 };
 
                 // do extra check when bit_offset is in "range mode"
                 if let BitOffset::Cursed(ranges) = &f.bit_offset {
+                    // "range mode" doesn't support array
+                    if f.array.is_some() {
+                        errs.push(format!(
+                            "fieldset {} field {}: \"range mode\" of bit_offset doesn't support array",
+                            fsname, f.name
+                        ));
+                        continue;
+                    };
+
                     let mut last_max_index = 0;
                     let mut ranges_size = 0;
                     for (index, range) in ranges.iter().enumerate() {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -94,15 +94,6 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
 
                 // do extra check when bit_offset is in "range mode"
                 if let BitOffset::Cursed(ranges) = &f.bit_offset {
-                    // "range mode" doesn't support array
-                    if f.array.is_some() {
-                        errs.push(format!(
-                            "fieldset {} field {}: \"range mode\" of bit_offset doesn't support array",
-                            fsname, f.name
-                        ));
-                        continue;
-                    };
-
                     let mut last_max_index = 0;
                     let mut ranges_size = 0;
                     for (index, range) in ranges.iter().enumerate() {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
+use std::{cmp::Ordering, collections::HashSet};
 
-use crate::ir::{BlockItemInner, IR};
+use crate::ir::{BitOffset, BlockItemInner, IR};
 
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -80,7 +80,7 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
             errs.push(format!("fieldset {} is unused", fsname));
         }
 
-        for f in &fs.fields {
+        'FIELD: for f in &fs.fields {
             if let Some(ename) = &f.enumm {
                 used_enums.insert(ename.clone());
 
@@ -91,6 +91,54 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                     ));
                     continue
                 };
+
+                // do extra check when bit_offset is in "range mode"
+                if let BitOffset::Cursed(ranges) = f.bit_offset {
+                    let mut last_max_index = 0;
+                    let mut ranges_size = 0;
+                    for (index, range) in ranges.iter().enumerate() {
+                        // every "range" shouldn't be empty (aka start > end)
+                        if range.is_empty() {
+                            errs.push(format!(
+                                "fieldset {} field {}: end value of bit_offset is bigger than start value",
+                                fsname, f.name,
+                            ));
+                            continue 'FIELD;
+                        }
+
+                        // "range"s of same field shouldn't overlap
+                        if index > 0 {
+                            match range.start().cmp(&last_max_index) {
+                                Ordering::Less => {
+                                    errs.push(format!(
+                                    "fieldset {} field {}: bit_offset is overlapped with itself",
+                                    fsname, f.name,
+                                ));
+                                    continue 'FIELD;
+                                }
+                                Ordering::Equal => {
+                                    errs.push(format!(
+                                        "fieldset {} field {}: bit_offset has continuous part, should be merged",
+                                        fsname, f.name,
+                                    ));
+                                    continue 'FIELD;
+                                }
+                                Ordering::Greater => last_max_index = *range.end(),
+                            }
+                        }
+                        ranges_size += range.end() - range.start() + 1;
+                    }
+
+                    // bit size from "ranges" should be the same as field bit_size
+                    if ranges_size != f.bit_size {
+                        errs.push(format!(
+                            "fieldset {} field {}: size of bit_offset ranges is mismatch with field bit_size",
+                            fsname, f.name,
+                        ));
+                        continue;
+                    }
+                }
+
                 if f.bit_size != e.bit_size {
                     errs.push(format!(
                         "fieldset {} field {}: bit_size {} does not match enum {} bit_size {}",
@@ -102,13 +150,18 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
 
         if !options.allow_field_overlap {
             for (i1, i2) in Pairs::new(fs.fields.iter()) {
-                if i2.bit_offset + i2.bit_size > i1.bit_offset
-                    && i1.bit_offset + i1.bit_size > i2.bit_offset
-                {
-                    errs.push(format!(
-                        "fieldset {}: fields overlap: {} {}",
-                        fsname, i1.name, i2.name
-                    ));
+                // expand every BitOffset to a Vec<RangeInclusive>,
+                // and compare at that level
+                'COMPARE: for i1_range in i1.bit_offset.into_ranges(i1.bit_size) {
+                    for i2_range in i2.bit_offset.into_ranges(i2.bit_size) {
+                        if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
+                            errs.push(format!(
+                                "fieldset {}: fields overlap: {} {}",
+                                fsname, i1.name, i2.name
+                            ));
+                            break 'COMPARE;
+                        }
+                    }
                 }
             }
         }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -93,7 +93,7 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                 };
 
                 // do extra check when bit_offset is in "range mode"
-                if let BitOffset::Cursed(ranges) = f.bit_offset {
+                if let BitOffset::Cursed(ranges) = &f.bit_offset {
                     let mut last_max_index = 0;
                     let mut ranges_size = 0;
                     for (index, range) in ranges.iter().enumerate() {
@@ -152,8 +152,8 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
             for (i1, i2) in Pairs::new(fs.fields.iter()) {
                 // expand every BitOffset to a Vec<RangeInclusive>,
                 // and compare at that level
-                'COMPARE: for i1_range in i1.bit_offset.into_ranges(i1.bit_size) {
-                    for i2_range in i2.bit_offset.into_ranges(i2.bit_size) {
+                'COMPARE: for i1_range in i1.bit_offset.clone().into_ranges(i1.bit_size) {
+                    for i2_range in i2.bit_offset.clone().into_ranges(i2.bit_size) {
                         if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
                             errs.push(format!(
                                 "fieldset {}: fields overlap: {} {}",


### PR DESCRIPTION
I found some "discontinuous field" when I make timer_v2.
eg. 
`MMS` of `TIMx_CR2` from Page1567 of Section38 AdvTim of H573 [RM0481];
`TS` of `TIMx_SMCR` from the same page.

I try add support for this situation.

------

yaml file will support

```yaml
fieldset/CR2_2CH_CMP:
  extends: CR2_1CH_CMP
  description: control register 2
  fields:
  - name: MMS
    description: Master mode selection
    bit_offset:
      - start: 4
        end: 6
      - start: 25
        end: 25
    bit_size: 4
    enum: MMS
```

new syntax, and chiptool do properly check when parse source file.

It will generate PAC like this:

```rust
#[doc = "Master mode selection"]
#[inline(always)]
pub const fn mms(&self) -> super::vals::Mms {
    let mut val = 0;
    val += (((self.0 >> 4usize) & 0x07) << 0usize);
    val += (((self.0 >> 25usize) & 0x01) << 3usize);
    super::vals::Mms::from_bits(val as u8)
}
#[doc = "Master mode selection"]
#[inline(always)]
pub fn set_mms(&mut self, val: super::vals::Mms) {
    self.0 = (self.0 & !(0x07 << 4usize)) | (((val.to_bits() as u32 >> 0usize) & 0x07) << 4usize);
    self.0 = (self.0 & !(0x01 << 25usize)) | (((val.to_bits() as u32 >> 3usize) & 0x01) << 25usize);
}
``` 

And for fields array:

```yaml
  - name: OCM
    description: Output compare y mode
    bit_offset:
      - start: 4
        end: 6
      - start: 16
        end: 16
    bit_size: 4
    array:
      len: 2
      stride: 8
    enum: OCM
```

it will generate:

```rust
#[doc = "Output compare y mode"]
#[inline(always)]
pub const fn ocm(&self, n: usize) -> super::vals::Ocm {
    assert!(n < 1usize);
    let mut val = 0;
    let offs = 4usize + n * 8usize;
    val += (((self.0 >> offs) & 0x07) << 0usize);
    let offs = 16usize + n * 8usize;
    val += (((self.0 >> offs) & 0x01) << 3usize);
    super::vals::Ocm::from_bits(val as u8)
}
#[doc = "Output compare y mode"]
#[inline(always)]
pub fn set_ocm(&mut self, n: usize, val: super::vals::Ocm) {
    assert!(n < 1usize);
    let offs = 4usize + n * 8usize;
    self.0 = (self.0 & !(0x07 << offs)) | (((val.to_bits() as u32 >> 0usize) & 0x07) << offs);
    let offs = 16usize + n * 8usize;
    self.0 = (self.0 & !(0x01 << offs)) | (((val.to_bits() as u32 >> 3usize) & 0x01) << offs);
}
```

------

I didn't touch the output of regular bit_offset (though regluar bit_offset can also be write as 1-range bit_offset), I think we should keep as simple as possible, since access registers can be "hot paths".

[RM0481]: https://www.st.com/resource/en/reference_manual/rm0481-stm32h563h573-and-stm32h562-armbased-32bit-mcus-stmicroelectronics.pdf