### PR TITLE
allow negative byte offset

### DIFF
--- a/src/transform/modify_byte_offset.rs
+++ b/src/transform/modify_byte_offset.rs
@@ -5,19 +5,49 @@ use crate::ir::*;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModifyByteOffset {
-    pub block: String,
-    pub add_offset: u32,
+    pub blocks: String,
+    pub exclude_items: Option<String>,
+    pub add_offset: i32,
 }
 
 impl ModifyByteOffset {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
-        let path_re = make_regex(&self.block)?;
+        let path_re = make_regex(&self.blocks)?;
+        let ex_re = if let Some(exclude_items) = &self.exclude_items {
+            make_regex(exclude_items)?
+        } else {
+            make_regex("")?
+        };
+
+        let mut err_names = Vec::new();
+
         for id in match_all(ir.blocks.keys().cloned(), &path_re) {
             let b = ir.blocks.get_mut(&id).unwrap();
             for i in &mut b.items {
-                i.byte_offset += self.add_offset;
+                if ex_re.is_match(&i.name) {
+                    continue;
+                }
+
+                match i.byte_offset.checked_add_signed(self.add_offset) {
+                    Some(new_offset) => i.byte_offset = new_offset,
+                    None => err_names.push((id.clone(), i.name.clone())),
+                };
             }
         }
+
+        if !err_names.is_empty() {
+            let mut err_msg = String::new();
+
+            for e_name in err_names {
+                err_msg.push_str(&format!(
+                    "Block: {} Item: {}: byte_offset out of range after modify\n",
+                    e_name.0, e_name.1
+                ));
+            }
+
+            panic!("{err_msg}")
+        }
+
         Ok(())
     }
 }

--- a/src/transform/modify_byte_offset.rs
+++ b/src/transform/modify_byte_offset.rs
@@ -8,6 +8,7 @@ pub struct ModifyByteOffset {
     pub blocks: String,
     pub exclude_items: Option<String>,
     pub add_offset: i32,
+    pub strict: Option<bool>, // if this value is false, bypass overflowed/underflowed modification
 }
 
 impl ModifyByteOffset {
@@ -18,6 +19,8 @@ impl ModifyByteOffset {
         } else {
             make_regex("")?
         };
+
+        let strict = self.strict.unwrap_or_default();
 
         let mut err_names = Vec::new();
 
@@ -30,7 +33,8 @@ impl ModifyByteOffset {
 
                 match i.byte_offset.checked_add_signed(self.add_offset) {
                     Some(new_offset) => i.byte_offset = new_offset,
-                    None => err_names.push((id.clone(), i.name.clone())),
+                    None if strict => err_names.push((id.clone(), i.name.clone())),
+                    None => (),
                 };
             }
         }


### PR DESCRIPTION
allow something like this:

```yaml
transforms:
  - !ModifyByteOffset
    blocks: ADC_COMMON
    exclude_items: ^CDR$
    add_offset: -768 # 0x300
```

can output errors (when use with `strict: true` and do a rerun) like this:

```text
thread 'main' panicked at src/transform/modify_byte_offset.rs:48:13:
Block: ADC_COMMON Item: CSR: byte_offset out of range after modify
Block: ADC_COMMON Item: CCR: byte_offset out of range after modify
Block: ADC_COMMON Item: HWCFGR0: byte_offset out of range after modify
Block: ADC_COMMON Item: VERR: byte_offset out of range after modify
Block: ADC_COMMON Item: IPDR: byte_offset out of range after modify
Block: ADC_COMMON Item: SIDR: byte_offset out of range after modify

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Notice:

value range of `add_offset` from `u32` to `i32`