### PR TITLE
fieldset: respect access type (R/W, R, W)

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -203,6 +203,8 @@ pub struct Field {
     pub description: Option<String>,
     pub bit_offset: BitOffset,
     pub bit_size: u32,
+    #[serde(default = "default_readwrite", skip_serializing_if = "is_readwrite")]
+    pub access: Access,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub array: Option<Array>,
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "enum")]

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -271,11 +271,21 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                 warn!("unsupported derived_from in fieldset");
             }
 
+            let access = match f.access {
+                None => Access::ReadWrite,
+                Some(svd::Access::ReadOnly) => Access::Read,
+                Some(svd::Access::WriteOnly) => Access::Write,
+                Some(svd::Access::WriteOnce) => Access::Write,
+                Some(svd::Access::ReadWrite) => Access::ReadWrite,
+                Some(svd::Access::ReadWriteOnce) => Access::ReadWrite,
+            };
+
             let mut field = Field {
                 name: f.name.clone(),
                 description: f.description.clone(),
                 bit_offset: BitOffset::Regular(f.bit_range.offset),
                 bit_size: f.bit_range.width,
+                access: access,
                 array: None,
                 enumm: None,
             };

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -34,6 +34,7 @@ impl FixRegisterBitSizes {
                                             bit_offset: BitOffset::Regular(0),
                                             bit_size: orig_bit_size,
                                             description: None,
+                                            access: Access::ReadWrite,
                                             enumm: None,
                                             array: None,
                                         }],


### PR DESCRIPTION
Some fields in a register may be R/W, Read-only or Write-only. For those Read-only, do not generate `{name}_set` call. Similarly, for those Write-only, do not generate `{name}` call.