### PR TITLE
Switch `rust-toolchain.toml` to latest stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.31"
+version = "0.9.34-deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
+checksum = "d4f17ab28832fcb8e88a0e938aaa915b4f4618142bd011d4e6a3060028974c47"
 dependencies = [
  "indexmap",
  "itoa",
@@ -373,9 +373,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro2 = "1.0"
 anyhow = "1.0.79"
 regex = "1.10.3"
 serde = { version = "1.0.196", features = [ "derive" ]}
-serde_yaml = "0.9.31"
 svd-parser = { git = "https://github.com/Dirbaio/svd.git", rev = "1bbf7d870a42bf1d17cc84e840d5f5d1cd0a0fa7", features = ["derive-from", "expand"] }
 #svd-parser = { path = "./svd/svd-parser", features = ["derive-from", "expand"] }
+# Development has stopped for `serde_yaml`
+serde_yaml = "=0.9.34-deprecated"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 ## PACs using chiptool
 
-Tested with the RP2040 SVD. Other SVDs might not work quite right yet.
+It is mainly used by [Embassy project][embassy] to generate PACs targeting
+Raspberry Pi RP2040 and RP2350, Atmel STM32-series and Nordic Semiconductor
+nRF5x-series microcontrollers. Other SVDs might not work quite right yet.
 
 - https://github.com/embassy-rs/rp-pac
 - https://github.com/embassy-rs/nrf-pac
@@ -251,4 +253,5 @@ Conduct][coc], the maintainer of this crate, the [Tools team][team], promises
 to intervene to uphold that code of conduct.
 
 [coc]: CODE_OF_CONDUCT.md
+[embassy]: https://embassy.dev/
 [team]: https://github.com/rust-embedded/wg#the-tools-team

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-12-20"
+channel = "1.82"
 components = [ "rust-src", "rustfmt" ]


### PR DESCRIPTION
Mainly to address #37, but misc other nitpicks.