### PR TITLE
Add DeletePeripherals.

### DIFF
--- a/src/transform/delete_peripherals.rs
+++ b/src/transform/delete_peripherals.rs
@@ -1,0 +1,24 @@
+use log::*;
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeletePeripherals {
+    pub devices: RegexSet,
+    pub from: RegexSet,
+}
+
+impl DeletePeripherals {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.devices.keys().cloned(), &self.devices) {
+            let d = ir.devices.get_mut(&id).unwrap();
+            d.peripherals.retain(|i| {
+                info!("deleting peripheral {}", &i.name);
+                !self.from.is_match(&i.name)
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -242,6 +242,7 @@ transforms!(
     delete_enums_used_in::DeleteEnumsUsedIn,
     delete_useless_enums::DeleteUselessEnums,
     delete_fieldsets::DeleteFieldsets,
+    delete_peripherals::DeletePeripherals,
     delete_registers::DeleteRegisters,
     merge_blocks::MergeBlocks,
     merge_enums::MergeEnums,


### PR DESCRIPTION
Add `DeletePeripherals` transform to delete peripherals from specific devices. This will not delete related blocks, regs and vals.

```yaml
transforms:
  - !DeletePeripherals
    devices: .*
    from: PORT
```