### PR TITLE
Add includes to Config.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,13 +271,16 @@ fn gen(args: Generate) -> Result<()> {
 fn transform(args: Transform) -> Result<()> {
     let data = fs::read(&args.input)?;
     let mut ir: IR = serde_yaml::from_slice(&data)?;
-    let config = load_config(&args.transform)?;
-    if let Some(transforms) = &config.transforms {
-        for t in transforms {
-            info!("running: {:?}", t);
-            t.run(&mut ir)?;
-        }
-    }
+    // let config = load_config(&args.transform)?;
+    // if let Some(transforms) = &config.transforms {
+    //     for t in transforms {
+    //         info!("running: {:?}", t);
+    //         t.run(&mut ir)?;
+    //     }
+    // }
+
+    apply_transform(&mut ir, args.transform)?;
+
     let data = serde_yaml::to_string(&ir)?;
     fs::write(&args.output, data.as_bytes())?;
 
@@ -394,26 +397,28 @@ fn gen_block(args: GenBlock) -> Result<()> {
 }
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 struct Config {
-    includes: Option<Vec<String>>,
-    transforms: Option<Vec<chiptool::transform::Transform>>,
+    #[serde(default)]
+    includes: Vec<String>,
+    #[serde(default)]
+    transforms: Vec<chiptool::transform::Transform>,
 }
 
 fn apply_transform<P: AsRef<std::path::Path>>(ir: &mut IR, p: P) -> anyhow::Result<()> {
     info!("applying transform {}", p.as_ref().display());
     let config = load_config(p.as_ref().to_str().unwrap())?;
 
-    if let Some(includes) = &config.includes {
-        for include in includes {
-            let subp = p.as_ref().parent().unwrap().join(include);
-            apply_transform(ir, subp)?;
-        }
+    // if let Some(includes) = &config.includes {
+    for include in &config.includes {
+        let subp = p.as_ref().parent().unwrap().join(include);
+        apply_transform(ir, subp)?;
     }
-    if let Some(transforms) = &config.transforms {
-        for transform in transforms {
-            info!("running {:?}", transform);
-            transform.run(ir)?;
-        }
+    // }
+    // if let Some(transforms) = &config.transforms {
+    for transform in &config.transforms {
+        info!("running {:?}", transform);
+        transform.run(ir)?;
     }
+    // }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,14 +271,6 @@ fn gen(args: Generate) -> Result<()> {
 fn transform(args: Transform) -> Result<()> {
     let data = fs::read(&args.input)?;
     let mut ir: IR = serde_yaml::from_slice(&data)?;
-    // let config = load_config(&args.transform)?;
-    // if let Some(transforms) = &config.transforms {
-    //     for t in transforms {
-    //         info!("running: {:?}", t);
-    //         t.run(&mut ir)?;
-    //     }
-    // }
-
     apply_transform(&mut ir, args.transform)?;
 
     let data = serde_yaml::to_string(&ir)?;
@@ -407,18 +399,14 @@ fn apply_transform<P: AsRef<std::path::Path>>(ir: &mut IR, p: P) -> anyhow::Resu
     info!("applying transform {}", p.as_ref().display());
     let config = load_config(p.as_ref().to_str().unwrap())?;
 
-    // if let Some(includes) = &config.includes {
     for include in &config.includes {
         let subp = p.as_ref().parent().unwrap().join(include);
         apply_transform(ir, subp)?;
     }
-    // }
-    // if let Some(transforms) = &config.transforms {
     for transform in &config.transforms {
         info!("running {:?}", transform);
         transform.run(ir)?;
     }
-    // }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,8 @@ fn apply_transform<P: AsRef<std::path::Path>>(ir: &mut IR, p: P) -> anyhow::Resu
     }
     if let Some(transforms) = &config.transforms {
         for transform in transforms {
-            transform.run(ir);
+            info!("running {:?}", transform);
+            transform.run(ir)?;
         }
     }
 


### PR DESCRIPTION
This PR implement a `includes` in transforms.

`includes` and `transforms` can be empty. Files list in `includes` are related to current yaml file.

This design is compatible.

Example:

```yaml
# some_device.yaml
includes:
  - peripheral_a.yaml
transforms:
  - ...
```

```yaml
# peripheral_a.yaml
transforms:
  - ...
```
