### PR TITLE
Add Add.

### DIFF
--- a/src/transform/add.rs
+++ b/src/transform/add.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Add {
+    ir: IR,
+}
+
+impl Add {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        ir.merge(self.ir.clone());
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -236,6 +236,7 @@ macro_rules! transforms {
 transforms!(
     sanitize::Sanitize,
     sort::Sort,
+    add::Add,
     delete::Delete,
     delete_enums::DeleteEnums,
     delete_enums_with_variants::DeleteEnumsWithVariants,


### PR DESCRIPTION
Add an `Add` transform, like `_add` in svdtools.

This will override if exists.

Example:
```yaml
transforms:
  - !Add
    ir:
      block/test_periph::TestPeripheral:
        description: TEST Added PERIPHERAL
        items:
          - name: TestReg
            description: TEST Added Fieldset
            byte_offset: 0
            access: Read
      fieldset/test_periph::regs::TestReg:
        description: Test Register
        fields:
          - name: some_val
            bit_offset: 0
            bit_size: 1
            enum: test_periph::vals::TestVal
      enum/test_periph::vals::TestVal:
        bit_size: 1
        variants:
          - name: ENABLE
            description: ENABLE
            value: 1
          - name: DISABLE
            description: DISABLE
            value: 0
```
          