### PR TITLE
Add access for field

### DIFF
--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -31,6 +31,9 @@ pub fn render(_opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Res
         let to_bits: TokenStream;
         let from_bits: TokenStream;
 
+        let have_read: bool = f.access == Access::Read || f.access == Access::ReadWrite;
+        let have_write: bool = f.access == Access::Write || f.access == Access::ReadWrite;
+
         if let Some(e_path) = &f.enumm {
             let Some(e) = ir.enums.get(e_path) else {
                 panic!("missing enum {}", e_path);
@@ -69,37 +72,49 @@ pub fn render(_opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Res
                 let off_in_reg = off_in_reg as usize;
                 if let Some(array) = &f.array {
                     let (len, offs_expr) = super::process_array(array);
-                    items.extend(quote!(
-                        #doc
-                        #[inline(always)]
-                        pub const fn #name(&self, n: usize) -> #field_ty{
-                            assert!(n < #len);
-                            let offs = #off_in_reg + #offs_expr;
-                            let val = (self.0 >> offs) & #mask;
-                            #from_bits
-                        }
-                        #doc
-                        #[inline(always)]
-                        pub fn #name_set(&mut self, n: usize, val: #field_ty) {
-                            assert!(n < #len);
-                            let offs = #off_in_reg + #offs_expr;
-                            self.0 = (self.0 & !(#mask << offs)) | (((#to_bits) & #mask) << offs);
-                        }
-                    ));
+                    if have_read {
+                        items.extend(quote! {
+                            #doc
+                            #[inline(always)]
+                            pub const fn #name(&self, n: usize) -> #field_ty{
+                                assert!(n < #len);
+                                let offs = #off_in_reg + #offs_expr;
+                                let val = (self.0 >> offs) & #mask;
+                                #from_bits
+                            }
+                        });
+                    }
+                    if have_write {
+                        items.extend(quote! {
+                            #doc
+                            #[inline(always)]
+                            pub fn #name_set(&mut self, n: usize, val: #field_ty) {
+                                assert!(n < #len);
+                                let offs = #off_in_reg + #offs_expr;
+                                self.0 = (self.0 & !(#mask << offs)) | (((#to_bits) & #mask) << offs);
+                            }
+                        });
+                    }
                 } else {
-                    items.extend(quote!(
-                        #doc
-                        #[inline(always)]
-                        pub const fn #name(&self) -> #field_ty{
-                            let val = (self.0 >> #off_in_reg) & #mask;
-                            #from_bits
-                        }
-                        #doc
-                        #[inline(always)]
-                        pub fn #name_set(&mut self, val: #field_ty) {
-                            self.0 = (self.0 & !(#mask << #off_in_reg)) | (((#to_bits) & #mask) << #off_in_reg);
-                        }
-                    ));
+                    if have_read {
+                        items.extend(quote! {
+                            #doc
+                            #[inline(always)]
+                            pub const fn #name(&self) -> #field_ty{
+                                let val = (self.0 >> #off_in_reg) & #mask;
+                                #from_bits
+                            }
+                        });
+                    }
+                    if have_write {
+                        items.extend(quote! {
+                            #doc
+                            #[inline(always)]
+                            pub fn #name_set(&mut self, val: #field_ty) {
+                                self.0 = (self.0 & !(#mask << #off_in_reg)) | (((#to_bits) & #mask) << #off_in_reg);
+                            }
+                        });
+                    }
                 }
             }
             BitOffset::Cursed(ranges) => {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -201,6 +201,8 @@ pub struct Field {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(default = "default_readwrite", skip_serializing_if = "is_readwrite")]
+    pub access: Access,
     pub bit_offset: BitOffset,
     pub bit_size: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -271,10 +271,18 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
             if f.derived_from.is_some() {
                 warn!("unsupported derived_from in fieldset");
             }
-
+            let access = match f.access {
+                None => Access::ReadWrite,
+                Some(svd::Access::ReadOnly) => Access::Read,
+                Some(svd::Access::WriteOnly) => Access::Write,
+                Some(svd::Access::WriteOnce) => Access::Write,
+                Some(svd::Access::ReadWrite) => Access::ReadWrite,
+                Some(svd::Access::ReadWriteOnce) => Access::ReadWrite,
+            };
             let mut field = Field {
                 name: f.name.clone(),
                 description: f.description.clone(),
+                access: access,
                 bit_offset: BitOffset::Regular(f.bit_range.offset),
                 bit_size: f.bit_range.width,
                 array: None,

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -31,6 +31,7 @@ impl FixRegisterBitSizes {
                                         bit_size: good_bit_size,
                                         fields: vec![Field {
                                             name: "val".to_string(),
+                                            access: Access::ReadWrite,
                                             bit_offset: BitOffset::Regular(0),
                                             bit_size: orig_bit_size,
                                             description: None,


### PR DESCRIPTION
Add access for field.

If a field is `read`/`write` only, it will only generate `#name`/`set_#name` method to avoid UB and decrease generated code size.