### PR TITLE
Implement Debug and defmt::Format for fieldsets, enums and the interrupt enum.

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -77,8 +77,10 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
         }
     }
     let n = util::unsuffixed(pos as u64);
+
     out.extend(quote!(
         #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Interrupt {
             #interrupts
         }

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -17,7 +17,7 @@ pub fn render_device_x(_ir: &IR, d: &Device) -> Result<String> {
     Ok(device_x)
 }
 
-pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<TokenStream> {
+pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<TokenStream> {
     let mut out = TokenStream::new();
     let span = Span::call_site();
 
@@ -78,9 +78,15 @@ pub fn render(_opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result
     }
     let n = util::unsuffixed(pos as u64);
 
+    let defmt = opts.defmt_feature.as_ref().map(|defmt_feature| {
+        quote! {
+            #[cfg_attr(feature = #defmt_feature, derive(defmt::Format))]
+        }
+    });
+
     out.extend(quote!(
         #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        #defmt
         pub enum Interrupt {
             #interrupts
         }

--- a/src/generate/enumm.rs
+++ b/src/generate/enumm.rs
@@ -10,7 +10,7 @@ use crate::util;
 
 use super::sorted;
 
-pub fn render(_opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<TokenStream> {
+pub fn render(opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<TokenStream> {
     let span = Span::call_site();
 
     // For very "sparse" enums, generate a newtype wrapping the uX.
@@ -50,6 +50,22 @@ pub fn render(_opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<
             ));
         }
 
+        let defmt = opts.defmt_feature.as_ref().map(|defmt_feature| {
+            quote! {
+                #[cfg(feature = #defmt_feature)]
+                impl defmt::Format for #name {
+                    fn format(&self, f: defmt::Formatter) {
+                        match self.0 {
+                            #(
+                                #item_values => defmt::write!(f, #item_names_str),
+                            )*
+                            other => defmt::write!(f, "0x{:02X}", other),
+                        }
+                    }
+                }
+            }
+        });
+
         out.extend(quote! {
             #doc
             #[repr(transparent)]
@@ -81,17 +97,8 @@ pub fn render(_opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<
                 }
             }
 
-            #[cfg(feature = "defmt")]
-            impl defmt::Format for #name {
-                fn format(&self, f: defmt::Formatter) {
-                    match self.0 {
-                        #(
-                            #item_values => defmt::write!("{}", #item_names_str),
-                        )*
-                        other => defmt::write!(f, "0x{:02X}", other),
-                    }
-                }
-            }
+            #defmt
+
         });
     } else {
         let variants: BTreeMap<_, _> = e.variants.iter().map(|v| (v.value, v)).collect();
@@ -114,11 +121,17 @@ pub fn render(_opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<
             }
         }
 
+        let defmt = opts.defmt_feature.as_ref().map(|defmt_feature| {
+            quote! {
+                #[cfg_attr(feature = #defmt_feature, derive(defmt::Format))]
+            }
+        });
+
         out.extend(quote! {
             #doc
             #[repr(#ty)]
             #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-            #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+            #defmt
             pub enum #name {
                 #items
             }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -59,21 +59,75 @@ impl Module {
     }
 }
 
+#[derive(Debug, Default)]
 pub enum CommonModule {
+    #[default]
     Builtin,
     External(TokenStream),
 }
 
+/// Options for the code generator.
+///
+/// See the individual methods for the different options you can change.
+#[derive(Debug)]
 pub struct Options {
-    pub common_module: CommonModule,
+    common_module: CommonModule,
+    defmt_feature: Option<String>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Options {
+    /// Create new options with all values set to the default.
+    ///
+    /// This will use a builtin common module,
+    /// and adds `defmt` support to the generated code gated behind a `feature = "defmt"` flag.
+    pub fn new() -> Self {
+        Self {
+            common_module: CommonModule::Builtin,
+            defmt_feature: Some("defmt".into()),
+        }
+    }
+
+    /// Get the path to the common module.
     fn common_path(&self) -> TokenStream {
         match &self.common_module {
             CommonModule::Builtin => TokenStream::from_str("crate::common").unwrap(),
             CommonModule::External(path) => path.clone(),
         }
+    }
+
+    /// Get the configuration of the common module.
+    pub fn common_module(&self) -> &CommonModule {
+        &self.common_module
+    }
+
+    /// Set the common module to use.
+    ///
+    /// Specify [`CommonModule::Builtin`] for a built-in common module,
+    /// or [`CommonModule::External`] to use an external common module.
+    pub fn with_common_module(mut self, common_module: CommonModule) -> Self {
+        self.common_module = common_module;
+        self
+    }
+
+    /// Set the feature for adding defmt support in the generated code.
+    ///
+    /// You can fully remove `defmt` support in the generated code by specifying `None`.
+    pub fn with_defmt_feature(mut self, defmt_feature: Option<String>) -> Self {
+        self.defmt_feature = defmt_feature;
+        self
+    }
+
+    /// Get the feature flag used to enable/disable `defmt` support in the generated code.
+    ///
+    /// If set to `None`, no `defmt` support will be added at all to the generated code.
+    pub fn defmt_feature(&self) -> Option<&str> {
+        self.defmt_feature.as_deref()
     }
 }
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -99,6 +99,16 @@ pub enum Array {
     Cursed(CursedArray),
 }
 
+impl Array {
+    /// Get the number of elements in the array.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Regular(x) => x.len as usize,
+            Self::Cursed(x) => x.offsets.len(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RegularArray {
     pub len: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn gen(args: Generate) -> Result<()> {
     let items = generate::render(&ir, &generate_opts).unwrap();
     fs::write("lib.rs", items.to_string())?;
 
-    let device_x = generate::render_device_x(&ir, &ir.devices.values().next().unwrap())?;
+    let device_x = generate::render_device_x(&ir, ir.devices.values().next().unwrap())?;
     fs::write("device.x", device_x)?;
 
     Ok(())

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -474,13 +474,11 @@ fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
                         prefix.push('_');
                     }
                     prefix.push_str(s);
+                } else if prefix.is_empty() {
+                    res.push(s.clone());
                 } else {
-                    if prefix.is_empty() {
-                        res.push(s.clone());
-                    } else {
-                        res.push(format!("{prefix}_{s}"));
-                        prefix = String::new()
-                    }
+                    res.push(format!("{prefix}_{s}"));
+                    prefix = String::new()
                 }
             }
             if !prefix.is_empty() {

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -9,16 +9,16 @@ pub struct FixRegisterBitSizes {
 
 impl FixRegisterBitSizes {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
-        for (_, b) in &mut ir.blocks {
+        for b in ir.blocks.values_mut() {
             for i in &mut b.items {
                 if let BlockItemInner::Register(r) = &mut i.inner {
                     let orig_bit_size = r.bit_size;
                     let good_bit_size = match r.bit_size {
-                        ..=8 => 8,
-                        ..=16 => 16,
-                        ..=32 => 32,
-                        ..=64 => 64,
-                        _ => panic!("Invalid register bit size {}", r.bit_size),
+                        0..=8 => 8,
+                        9..=16 => 16,
+                        17..=32 => 32,
+                        33..=64 => 64,
+                        65.. => panic!("Invalid register bit size {}", r.bit_size),
                     };
                     if r.bit_size != good_bit_size {
                         r.bit_size = good_bit_size;

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -245,6 +245,7 @@ transforms!(
     delete_fieldsets::DeleteFieldsets,
     delete_peripherals::DeletePeripherals,
     delete_registers::DeleteRegisters,
+    expand_extends::ExpandExtends,
     merge_blocks::MergeBlocks,
     merge_enums::MergeEnums,
     merge_fieldsets::MergeFieldsets,


### PR DESCRIPTION
This PR:

* Implements the `Debug` and `defmt::Format` traits for generated fieldsets, value enums and interrupt enums.
  * Where possible the traits are simply derived.
  * The `defmt::Format` impls are disabled by default and must be enabled with a `"defmt"` feature.
* Re-adds the `expand_extends` transform which I think was accidentally removed during a refactor of the transform system (couldn't test this with the `stm32-metapac` crate otherwise).
* Fixes some clippy warnings.

I think the `Debug` and `defmt::Format` impls can help tremendously when debugging embedded applications :)

I've tested this by using it to regenerate the `stm32-metapac` crate, which added the trait impls as expected. I've also tested that the generated code compiles and looks as as expected. 