### PR TITLE
Add support for 'device' kind in IRVisitor

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -321,7 +321,7 @@ impl<'de> Visitor<'de> for IRVisitor {
         // into our map.
         while let Some(key) = access.next_key()? {
             let key: String = key;
-            let (kind, name) = key.split_once('/').ok_or(de::Error::custom("item names must be in form `kind/name`, where kind is `block`, `fieldset` or `enum`"))?;
+            let (kind, name) = key.split_once('/').ok_or(de::Error::custom("item names must be in form `kind/name`, where kind is `block`, `fieldset` `enum` or `device`"))?;
             match kind {
                 "block" => {
                     let val: Block = access.next_value()?;
@@ -338,6 +338,12 @@ impl<'de> Visitor<'de> for IRVisitor {
                 "enum" => {
                     let val: Enum = access.next_value()?;
                     if ir.enums.insert(name.to_string(), val).is_some() {
+                        return Err(de::Error::custom(format!("Duplicate item {:?}", key)));
+                    }
+                }
+                "device" => {
+                    let val: Device = access.next_value()?;
+                    if ir.devices.insert(name.to_string(), val).is_some() {
                         return Err(de::Error::custom(format!("Duplicate item {:?}", key)));
                     }
                 }


### PR DESCRIPTION
This is useful when adding an interrupt table using the `Add` transform.

Example:

```yaml
# Add interrupt table
- !Add
    ir:
      device/:
        peripherals:
        interrupts:
          - name: I2C1_IRQ
            value: 10
          - name: I2C2_IRQ
            value: 11  
```

In this example, the name of `device` is empty. This is because, at present, `chiptool` uses an empty string as the key for `device` when generating the `IR`, rather than using the `name` field from the SVD. I suspect there might be other reasons behind this.

https://github.com/embassy-rs/chiptool/blob/47bb90c57c0d9473e189376dbbaa762e5f812e7c/src/svd2ir.rs#L406