### PR TITLE
Add `AddInterrupts` transform

### DIFF
--- a/src/transform/add_interrupts.rs
+++ b/src/transform/add_interrupts.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddInterrupts {
+    pub devices: RegexSet,
+    pub interrupts: Vec<Interrupt>,
+}
+
+impl AddInterrupts {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.devices.keys().cloned(), &self.devices) {
+            let d = ir.devices.get_mut(&id).unwrap();
+            d.interrupts.extend(self.interrupts.clone());
+        }
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -237,6 +237,7 @@ transforms!(
     sanitize::Sanitize,
     sort::Sort,
     add::Add,
+    add_interrupts::AddInterrupts,
     delete::Delete,
     delete_enums::DeleteEnums,
     delete_enums_with_variants::DeleteEnumsWithVariants,


### PR DESCRIPTION
Add `AddInterrupts` transform.
example:
``` yaml
  - !AddInterrupts
      devices: .*
      interrupts:
        - name: I2C1_IRQ
          value: 10
          description: I2C1 interrupt

        - name: I2C2_IRQ
          value: 11
          description: I2C2 interrupt
```

Although some modifications in [svd2ir.rs](https://github.com/embassy-rs/chiptool/blob/main/src/svd2ir.rs) would allow the use of the `Add` transform to add device interrupts, the `Add` transform merges at the `Vec<Device>` level, which results in interrupts and peripherals being overwritten. Therefore, I have added the `AddInterrupts` transform.
