### PR TITLE
Add `DeleteFields` transform

### DIFF
--- a/src/transform/delete_fields.rs
+++ b/src/transform/delete_fields.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteFields {
+    pub fieldset: RegexSet,
+    pub from: RegexSet,
+}
+
+impl DeleteFields {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
+            let fs = ir.fieldsets.get_mut(&id).unwrap();
+            fs.fields.retain(|f| !self.from.is_match(&f.name));
+        }
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -242,6 +242,7 @@ transforms!(
     delete_enums_with_variants::DeleteEnumsWithVariants,
     delete_enums_used_in::DeleteEnumsUsedIn,
     delete_useless_enums::DeleteUselessEnums,
+    delete_fields::DeleteFields,
     delete_fieldsets::DeleteFieldsets,
     delete_peripherals::DeletePeripherals,
     delete_registers::DeleteRegisters,


### PR DESCRIPTION
Add `DeleteFields` transform.
example:
``` yaml
  - !DeleteFields
    fieldset: .*
    from: rsvd.*
```

I have checked the available transforms, but I couldn't find one that implements this functionality. If such a transform already exists, I will close this PR.