### PR TITLE
Add no_effect, clr and set to DeleteUselessEnums

### DIFF
--- a/src/transform/delete_useless_enums.rs
+++ b/src/transform/delete_useless_enums.rs
@@ -48,6 +48,7 @@ const USELESS_ZERO_NAMES: &[&str] = &[
     "disconnected",
     "not_detected",
     "invalid",
+    "no_effect",
 ];
 const USELESS_ONE_NAMES: &[&str] = &[
     "en",
@@ -62,6 +63,8 @@ const USELESS_ONE_NAMES: &[&str] = &[
     "connected",
     "detected",
     "valid",
+    "set",
+    "clr",
 ];
 
 const NOT_NAMES: &[&str] = &["not", "no", "un", "de", "in"];


### PR DESCRIPTION
These enum variants appear in the MSPM0 SVD files.

Examples:
```yaml
enum/ICLR_SYSPLLGOOD:
  bit_size: 1
  variants:
  - name: NO_EFFECT
    value: 0
  - name: CLR
    value: 1
enum/ISET_BORLVL:
  bit_size: 1
  variants:
  - name: NO_EFFECT
    value: 0
  - name: SET
    value: 1
```