### PR TITLE
Add passthru to DeleteUselessEnums

### DIFF
--- a/src/transform/delete_useless_enums.rs
+++ b/src/transform/delete_useless_enums.rs
@@ -49,6 +49,7 @@ const USELESS_ZERO_NAMES: &[&str] = &[
     "not_detected",
     "invalid",
     "no_effect",
+    "passthru",
 ];
 const USELESS_ONE_NAMES: &[&str] = &[
     "en",


### PR DESCRIPTION
The MSPM0 SVDs sometimes use `PASSTHRU` as the zero value for a useless enum.

Example:
```yaml
enum/EXCLKDIVEN:
  bit_size: 1
  variants:
  - name: PASSTHRU
    value: 0
  - name: ENABLE
    value: 1
```