### PR TITLE
Add DeleteEnumVariants transform

### DIFF
--- a/src/transform/delete_enum_variants.rs
+++ b/src/transform/delete_enum_variants.rs
@@ -1,0 +1,31 @@
+use log::*;
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeleteEnumVariants {
+    #[serde(rename = "enum")]
+    pub enumm: RegexSet,
+    pub from: RegexSet,
+}
+
+impl DeleteEnumVariants {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.enums.keys().cloned(), &self.enumm) {
+            let e = ir.enums.get_mut(&id).unwrap();
+
+            e.variants.retain(|variant| {
+                if self.from.is_match(&variant.name) {
+                    info!("deleting enum variant {}::{}", id, &variant.name);
+                    return false;
+                }
+
+                true
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -239,6 +239,7 @@ transforms!(
     add::Add,
     add_interrupts::AddInterrupts,
     delete::Delete,
+    delete_enum_variants::DeleteEnumVariants,
     delete_enums::DeleteEnums,
     delete_enums_with_variants::DeleteEnumsWithVariants,
     delete_enums_used_in::DeleteEnumsUsedIn,


### PR DESCRIPTION
Add `DeleteEnumVariants` transform. This exists because the SVDs for the MSPM0C110x contain enum variants which do not exist on the part.

The transform just removes variants which match. 

Example:
```yaml
  # Remove SYSOSCTURBO variants, not defined on C110x
  - !DeleteEnumVariants
    enum: (SYSOSCCFG_FREQ|SYSOSCFREQ)
    from: SYSOSCTURBO
```

Resolves #56