### PR TITLE
Add `ModifyFieldsEnum` transform

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -262,6 +262,7 @@ transforms!(
     make_field_array::MakeFieldArray,
     make_block::MakeBlock,
     modify_byte_offset::ModifyByteOffset,
+    modify_fields_enum::ModifyFieldsEnum,
     fix_register_bit_sizes::FixRegisterBitSizes,
     rename_interrupts::RenameInterrupts,
     rename_peripherals::RenamePeripherals,

--- a/src/transform/modify_fields_enum.rs
+++ b/src/transform/modify_fields_enum.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModifyFieldsEnum {
+    pub fieldset: RegexSet,
+    pub field: RegexSet,
+    #[serde(rename = "enum")]
+    pub enumm: RegexSet,
+}
+
+impl ModifyFieldsEnum {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        let matched_enums = match_all(ir.enums.keys().cloned(), &self.enumm);
+        if matched_enums.len() != 1 {
+            anyhow::bail!(
+                "Expected exactly one enum to match, found {}",
+                matched_enums.len()
+            );
+        }
+        let enum_id = matched_enums.first().unwrap().clone();
+
+        for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
+            let fs = ir.fieldsets.get_mut(&id).unwrap();
+            fs.fields
+                .iter_mut()
+                .filter(|f| self.field.is_match(&f.name))
+                .for_each(|f| f.enumm = Some(enum_id.clone()));
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Allows modifying a field's `enum` by binding the field to a specific enum.

We can also use `Add` and `ModifyFieldsEnum` to add an enum:

``` yaml
  - !Add
      ir:
        enum/rcc::vals::SelSys:
          bit_size: 2
          variants:
            - name: HSI
              value: 0
            - name: HSE
              value: 1
            - name: PLL
              value: 2
  
  - !ModifyFieldsEnum
      fieldset: rcc::regs::Dwcfgr
      field: sel_sys
      enum: rcc::vals::SelSys

```