### PR TITLE
Update svd-parser revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -258,15 +258,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "ryu"
@@ -315,8 +315,8 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "svd-parser"
-version = "0.14.7"
-source = "git+https://github.com/Dirbaio/svd.git?rev=8426f3bb40dd2391e26cd087a0d6510fe21fdcbc#8426f3bb40dd2391e26cd087a0d6510fe21fdcbc"
+version = "0.14.5"
+source = "git+https://github.com/Dirbaio/svd.git?rev=4d5c96f95b32acf9c9bfbda5a0619a2374475fe7#4d5c96f95b32acf9c9bfbda5a0619a2374475fe7"
 dependencies = [
  "anyhow",
  "roxmltree",
@@ -326,8 +326,8 @@ dependencies = [
 
 [[package]]
 name = "svd-rs"
-version = "0.14.9"
-source = "git+https://github.com/Dirbaio/svd.git?rev=8426f3bb40dd2391e26cd087a0d6510fe21fdcbc#8426f3bb40dd2391e26cd087a0d6510fe21fdcbc"
+version = "0.14.7"
+source = "git+https://github.com/Dirbaio/svd.git?rev=4d5c96f95b32acf9c9bfbda5a0619a2374475fe7#4d5c96f95b32acf9c9bfbda5a0619a2374475fe7"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro2 = "1.0"
 anyhow = "1.0.79"
 regex = "1.10.3"
 serde = { version = "1.0.196", features = [ "derive" ]}
-svd-parser = { git = "https://github.com/Dirbaio/svd.git", rev = "8426f3bb40dd2391e26cd087a0d6510fe21fdcbc", features = ["derive-from", "expand"] }
+svd-parser = { git = "https://github.com/Dirbaio/svd.git", rev = "4d5c96f95b32acf9c9bfbda5a0619a2374475fe7", features = ["derive-from", "expand"] }
 #svd-parser = { path = "./svd/svd-parser", features = ["derive-from", "expand"] }
 # Development has stopped for `serde_yaml`
 serde_yaml = "=0.9.34-deprecated"


### PR DESCRIPTION
After merging PR 1, svd-parser can parse SVDs without fpuPresent attributes. Update chiptool to latest parser so it can be used to extract peripherals from such SVD files.