### PR TITLE
Always allow non_camel_case_types and non_snake_case

### DIFF
--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -152,6 +152,8 @@ pub fn render(ir: &IR, opts: &Options) -> Result<TokenStream> {
     );
 
     root.items.extend(quote!(
+        #![allow(non_camel_case_types)]
+        #![allow(non_snake_case)]
         #![no_std]
         #![doc=#doc]
     ));


### PR DESCRIPTION
With this, we make sure that some enum variants will not generate a long list of warnings.