### PR TITLE
Make wrong use of write/modify give warnings

### DIFF
--- a/src/generate/common.rs
+++ b/src/generate/common.rs
@@ -68,20 +68,18 @@ impl<T: Copy, A: Write> Reg<T, A> {
 
 impl<T: Default + Copy, A: Write> Reg<T, A> {
     #[inline(always)]
-    pub fn write<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+    pub fn write(&self, f: impl FnOnce(&mut T)) {
         let mut val = Default::default();
-        let res = f(&mut val);
+        f(&mut val);
         self.write_value(val);
-        res
     }
 }
 
 impl<T: Copy, A: Read + Write> Reg<T, A> {
     #[inline(always)]
-    pub fn modify<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+    pub fn modify(&self, f: impl FnOnce(&mut T)) {
         let mut val = self.read();
-        let res = f(&mut val);
+        f(&mut val);
         self.write_value(val);
-        res
     }
 }

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -88,6 +88,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                     let (len, offs_expr) = super::process_array(array);
                     items.extend(quote!(
                         #doc
+                        #[must_use]
                         #[inline(always)]
                         pub const fn #name(&self, n: usize) -> #field_ty{
                             assert!(n < #len);
@@ -106,6 +107,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                 } else {
                     items.extend(quote!(
                         #doc
+                        #[must_use]
                         #[inline(always)]
                         pub const fn #name(&self) -> #field_ty{
                             let val = (self.0 >> #off_in_reg) & #mask;
@@ -145,6 +147,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                     let (len, offs_expr) = super::process_array(array);
                     items.extend(quote!(
                         #doc
+                        #[must_use]
                         #[inline(always)]
                         pub const fn #name(&self, n: usize) -> #field_ty{
                             assert!(n < #len);
@@ -164,6 +167,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                 } else {
                     items.extend(quote!(
                         #doc
+                        #[must_use]
                         #[inline(always)]
                         pub const fn #name(&self) -> #field_ty{
                             let mut val = 0;


### PR DESCRIPTION
This changes the `write` and `modify` API slightly such that one can get proper warnings when accidentally having the return value support hide that the write is not used.

From what I found by looking around I did not really see any use of the return value.