### PR TITLE
Add an option to generate `defmt` support unconditionally

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use crate::ir::*;
 use crate::util::{self, StringExt};
 
-use super::sorted;
+use super::{sorted, with_defmt_cfg_attr};
 
 pub fn render_device_x(_ir: &IR, d: &Device) -> Result<String> {
     let mut device_x = String::new();
@@ -78,15 +78,11 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
     }
     let n = util::unsuffixed(pos as u64);
 
-    let defmt = opts.defmt_feature.as_ref().map(|defmt_feature| {
-        quote! {
-            #[cfg_attr(feature = #defmt_feature, derive(defmt::Format))]
-        }
-    });
+    let derive_defmt = with_defmt_cfg_attr(&opts.defmt, quote! { derive(defmt::Format) });
 
     out.extend(quote!(
         #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-        #defmt
+        #derive_defmt
         pub enum Interrupt {
             #interrupts
         }


### PR DESCRIPTION
This PR implements three different options for `defmt` support in generated code:
- `DefmtOption::Disabled`: code that implements `defmt::Display` is not included in the generated code (as already implemented).
- `DefmtOption::Feature(feature)`: code for `defmt::Display` is gated behind a feature with given name (as already implemented).
- `DefmtOption::Enabled`: code for `defmt::Display` is included unconditionally (this option is new).

This is a breaking change in the API but backward compatible change in the CLI interface. I also added a CLI option `--yes-defmt` which corresponds to `DefmtOption::Enabled` (the opposite of `--no-defmt`, which maps to `DefmtOption::Disabled`).

This is useful when you want to include some code generated by `chiptool` into a larger crate where `defmt` is always available.