### PR TITLE
Add missing serde default attribute to Rename transform

### DIFF
--- a/src/transform/rename.rs
+++ b/src/transform/rename.rs
@@ -22,6 +22,7 @@ impl Default for RenameType {
 pub struct Rename {
     pub from: RegexSet,
     pub to: String,
+    #[serde(default)]
     pub r#type: RenameType,
 }
 


### PR DESCRIPTION
The Default impl was there but was not being used due to the missing attribute.

This broke generation in at least `rp-pac`.