### PR TITLE
Add ModifyRegisters transform

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -265,6 +265,7 @@ transforms!(
     make_block::MakeBlock,
     modify_byte_offset::ModifyByteOffset,
     modify_fields_enum::ModifyFieldsEnum,
+    modify_registers::ModifyRegisters,
     fix_register_bit_sizes::FixRegisterBitSizes,
     rename_interrupts::RenameInterrupts,
     rename_peripherals::RenamePeripherals,

--- a/src/transform/modify_registers.rs
+++ b/src/transform/modify_registers.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModifyRegisters {
+    pub blocks: RegexSet,
+    pub registers: RegexSet,
+    pub fieldset: Option<String>,
+}
+
+impl ModifyRegisters {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.blocks.keys().cloned(), &self.blocks) {
+            let block = ir.blocks.get_mut(&id).unwrap();
+
+            for item in block
+                .items
+                .iter_mut()
+                .filter(|i| self.registers.is_match(&i.name))
+            {
+                let BlockItemInner::Register(reg) = &mut item.inner else {
+                    continue;
+                };
+
+                if let Some(fieldset) = &self.fieldset {
+                    reg.fieldset = Some(fieldset.clone());
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This enables setting the fieldsets of registers if they are missing from the SVD.

I made it a generic "ModifyRegisters" transform because if somebody needs to change e.g. the accessibility of a register later, it could be added. Added to fix some DMA register aliases in `rp-pac` which do not have field information at all in the SVD, but simply alias the corresponding main registers so the same fieldset can be reused.

Works like this:

```yaml
  # Existing block
  - !MakeBlock
      blocks: dma::Dma
      from: ch(\d+)_(.*)
      to_block: dma::Channel
      to_outer: ch$1
      to_inner: $2
  # Add fieldsets for alias fields that do not have field information in SVD
  - !ModifyRegisters
      blocks: dma::Channel
      registers: al\d_ctrl
      fieldset: dma::regs::CtrlTrig
```