### PR TITLE
Use pointer wrapping add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 [[package]]
 name = "svd-parser"
 version = "0.14.5"
-source = "git+https://github.com/Dirbaio/svd.git?rev=4d5c96f95b32acf9c9bfbda5a0619a2374475fe7#4d5c96f95b32acf9c9bfbda5a0619a2374475fe7"
+source = "git+https://github.com/Dirbaio/svd.git?rev=04f062be3490dcc6d042e0dbec57b32d1bd6fa1c#04f062be3490dcc6d042e0dbec57b32d1bd6fa1c"
 dependencies = [
  "anyhow",
  "roxmltree",
@@ -327,7 +327,7 @@ dependencies = [
 [[package]]
 name = "svd-rs"
 version = "0.14.7"
-source = "git+https://github.com/Dirbaio/svd.git?rev=4d5c96f95b32acf9c9bfbda5a0619a2374475fe7#4d5c96f95b32acf9c9bfbda5a0619a2374475fe7"
+source = "git+https://github.com/Dirbaio/svd.git?rev=04f062be3490dcc6d042e0dbec57b32d1bd6fa1c#04f062be3490dcc6d042e0dbec57b32d1bd6fa1c"
 dependencies = [
  "once_cell",
  "regex",

--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -49,7 +49,7 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         #[inline(always)]
                         pub const fn #name(self, n: usize) -> #ty {
                             assert!(n < #len);
-                            unsafe { #common_path::Reg::from_ptr(self.ptr.add(#offset + #offs_expr) as _) }
+                            unsafe { #common_path::Reg::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
                         }
                     ));
                 } else {
@@ -57,7 +57,7 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         #doc
                         #[inline(always)]
                         pub const fn #name(self) -> #ty {
-                            unsafe { #common_path::Reg::from_ptr(self.ptr.add(#offset) as _) }
+                            unsafe { #common_path::Reg::from_ptr(self.ptr.wrapping_add(#offset) as _) }
                         }
                     ));
                 }
@@ -74,7 +74,7 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         #[inline(always)]
                         pub const fn #name(self, n: usize) -> #ty {
                             assert!(n < #len);
-                            unsafe { #ty::from_ptr(self.ptr.add(#offset + #offs_expr) as _) }
+                            unsafe { #ty::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
                         }
                     ));
                 } else {
@@ -82,7 +82,7 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         #doc
                         #[inline(always)]
                         pub const fn #name(self) -> #ty {
-                            unsafe { #ty::from_ptr(self.ptr.add(#offset) as _) }
+                            unsafe { #ty::from_ptr(self.ptr.wrapping_add(#offset) as _) }
                         }
                     ));
                 }


### PR DESCRIPTION
pointer::add on provenance-less pointers is unsound. The wrapping version is more tolerant.

The lockfile automatically updates, as it has diverged from the version specified in the TOML file. I split it into a separate commit in case you want to discard it.

I tested these changes by regenerating and cargo checking rp-pac using the script in that repo

Please let me know if anything else is needed 