### PR TITLE
Add `AddPeripherals` transform

### DIFF
--- a/src/transform/add_peripherals.rs
+++ b/src/transform/add_peripherals.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddPeripherals {
+    pub devices: RegexSet,
+    pub peripherals: Vec<Peripheral>,
+}
+
+impl AddPeripherals {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.devices.keys().cloned(), &self.devices) {
+            let d = ir.devices.get_mut(&id).unwrap();
+            d.peripherals.extend(self.peripherals.clone());
+        }
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -241,6 +241,7 @@ transforms!(
     add_fields::AddFields,
     add_registers::AddRegisters,
     add_interrupts::AddInterrupts,
+    add_peripherals::AddPeripherals,
     delete::Delete,
     delete_enum_variants::DeleteEnumVariants,
     delete_enums::DeleteEnums,


### PR DESCRIPTION
Adds the `AddPeripherals` transform, allowing peripherals to be appended to matching devices.

Example:

```YAML

  - !AddPeripherals
      devices: .*
      peripherals:
        - name: MAILBOX1
          base_address: 0x50082000
          block: mailbox::Mailbox
 ```
This follows the same motivation as the AddInterrupts transform.

The generic `Add` transform merges data at the top-level IR level. If Add were used to add a peripheral to an existing device, the IR::merge logic (or BTreeMap::extend) could cause the entire device entry to be replaced, overwriting the original lists of peripherals and interrupts for that device.