### PR TITLE
Tolerate duplicate enum variant names

### DIFF
--- a/src/generate/enumm.rs
+++ b/src/generate/enumm.rs
@@ -105,35 +105,12 @@ pub fn render(opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<T
         });
     } else {
         let variants: BTreeMap<_, _> = e.variants.iter().map(|v| (v.value, v)).collect();
-        let mut ident_counts: BTreeMap<String, _> = BTreeMap::new();
         let mut items = TokenStream::new();
-
         for val in 0..(1 << e.bit_size) {
             if let Some(f) = variants.get(&val) {
-                ident_counts.entry(f.name.clone())
-                    .and_modify(|c| *c += 1)
-                    .or_insert(1);
-            }
-        }
-
-        for val in 0..(1 << e.bit_size) {
-            if let Some(f) = variants.get(&val) {
-                let ident_name = {
-                    if ident_counts.get(&f.name).is_some_and(|c| *c > 1) {
-                        format!("{}_{:x}", f.name, f.value)
-                    } else {
-                        f.name.clone()
-                    }
-                };
-
-                let name = Ident::new(&ident_name, span);
+                let name = Ident::new(&f.name, span);
                 let value = util::hex(f.value);
                 let doc = util::doc(&f.description);
-
-                ident_counts.entry(ident_name)
-                    .and_modify(|c| *c += 1)
-                    .or_insert(1);
-
                 items.extend(quote!(
                     #doc
                     #name = #value,


### PR DESCRIPTION
Fixes issue https://github.com/embassy-rs/chiptool/issues/75

A duplicate in the enum variants in the svd would previously generate an enum like this:
```
enum Foo {
   BAR: 0x1,
   BAR: 0x2,
   BAR_2: 0x3,
   BAR: 0x4
}
```
Now, it will be generated into this:
```
enum Foo {
   BAR: 0x1,
   BAR_2: 0x2,
   BAR_2_2: 0x3,
   BAR_3: 0x4
}
```
This is done in one pass and will make sure of no conflicting names.