### PR TITLE
Fix extract peripheral regression

### DIFF
--- a/src/commands/extract_peripheral.rs
+++ b/src/commands/extract_peripheral.rs
@@ -2,7 +2,6 @@ use crate::commands::{load_svd, ExtractShared};
 use anyhow::Result;
 use clap::Parser;
 use std::io::stdout;
-use std::path::PathBuf;
 
 /// Extract peripheral from SVD to YAML and print to stdout.
 #[derive(Parser)]
@@ -10,9 +9,9 @@ pub struct ExtractPeripheral {
     #[clap(flatten)]
     pub extract_shared: ExtractShared,
 
-    /// Peripheral from the SVD
+    /// Name of peripheral from the SVD
     #[clap(long)]
-    pub peripheral: PathBuf,
+    pub peripheral: String,
 }
 
 pub fn extract_peripheral(args: ExtractPeripheral) -> Result<()> {


### PR DESCRIPTION
Introduced in [this commit](https://github.com/embassy-rs/chiptool/commit/f3016d8474f3dee320f99495f817059a0d88da61#diff-559af8081c1fb8c6d15fc60f0e9d073ae10d2eae3fc194c7b96e854f65cd958bR15) extract-peripheral became unusable because the peripheral name is almost never a path.