### PR TITLE
Implemented extract-all mode to align to generate

### DIFF
--- a/src/commands/extract_all.rs
+++ b/src/commands/extract_all.rs
@@ -1,8 +1,11 @@
-use crate::commands::{extract_peripheral, load_svd, ExtractShared};
-use anyhow::Result;
-use clap::Parser;
+use crate::commands::{apply_transform, clean_up_ir, extract_peripheral, load_svd, ExtractShared};
+use crate::ir::{self, IR};
+use crate::svd2ir;
+use anyhow::{anyhow, bail, Result};
+use clap::{Parser, ValueEnum};
+use std::collections::{BTreeSet, HashSet};
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Extract all peripherals from SVD to YAML
 #[derive(Parser)]
@@ -10,32 +13,54 @@ pub struct ExtractAll {
     #[clap(flatten)]
     pub extract_shared: ExtractShared,
 
+    /// The method employed to extract the data.
+    #[clap(long, default_value = "peripheral")]
+    pub mode: ExtractionMode,
+
     /// Output directory. Each peripheral will be created as a YAML file here.
     #[clap(short, long)]
     pub output: PathBuf,
 }
 
-pub fn extract_all(args: ExtractAll) -> Result<()> {
-    std::fs::create_dir_all(&args.output)?;
+#[derive(Clone, Copy, ValueEnum)]
+pub enum ExtractionMode {
+    /// The peripherals are extracted from the SVD directly, and transforms are applied on these individually.
+    Peripheral,
+    /// The SVD is extracted in its entirety and the transform are applied to that single IR tree.
+    ///
+    /// Afterwards the blocks associated with peripherals are extracted for this common IR.
+    Block,
+}
 
-    let svd = load_svd(&args.extract_shared.svd)?;
+pub fn extract_all(args: ExtractAll) -> Result<()> {
+    match args.mode {
+        ExtractionMode::Peripheral => extract_per_peripheral(&args.extract_shared, &args.output),
+        ExtractionMode::Block => extract_per_block(&args.extract_shared, &args.output),
+    }
+}
+
+/// Extract each peripheral directly from the SVD, apply transform, and write to disk.
+fn extract_per_peripheral(extract_shared: &ExtractShared, output_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(output_dir)?;
+
+    let svd = load_svd(&extract_shared.svd)?;
 
     for p in &svd.peripherals {
         if p.derived_from.is_some() {
             continue;
         }
 
-        let ir = extract_peripheral(
-            p,
-            &args.extract_shared.transform,
-            args.extract_shared.namespaces,
-        )?;
+        let mut ir = extract_peripheral(p, extract_shared.namespaces)?;
+
+        for transform in extract_shared.transform.iter() {
+            apply_transform(&mut ir, transform)?;
+        }
 
         if ir.blocks.is_empty() {
             continue;
         }
 
-        let f = File::create(PathBuf::from(&args.output).join(format!(
+        let f = File::create(PathBuf::from(output_dir).join(format!(
                 "{}.yaml",
                 // Take the shortest block name as the file name
                 ir.blocks
@@ -47,4 +72,139 @@ pub fn extract_all(args: ExtractAll) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Extract the entire SVD, apply transform, and then figure out which blocks correspond to the peripherals before writing to disk.
+fn extract_per_block(extract_shared: &ExtractShared, output_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(output_dir)?;
+
+    let svd = load_svd(&extract_shared.svd)?;
+    let mut ir = svd2ir::convert_svd(&svd, extract_shared.namespaces)?;
+
+    clean_up_ir(&mut ir)?;
+
+    for transform in extract_shared.transform.iter() {
+        apply_transform(&mut ir, transform)?;
+    }
+
+    let blocks: HashSet<String> = ir
+        .devices
+        .iter()
+        .flat_map(|(_, device)| device.peripherals.iter().flat_map(|p| &p.block))
+        .cloned()
+        .collect();
+
+    for block_name in blocks {
+        let block_ir = extract_relevant(&block_name, &ir)?;
+
+        let f = File::create(PathBuf::from(output_dir).join(format!("{}.yaml", block_name)))?;
+        serde_yaml::to_writer(f, &block_ir).unwrap();
+    }
+
+    Ok(())
+}
+
+/// Extract from an IR everything associated with a block.
+fn extract_relevant(block_name: &str, ir: &IR) -> Result<IR> {
+    #[derive(Default)]
+    struct Walker {
+        todos: BTreeSet<String>,
+        visited: BTreeSet<String>,
+    }
+
+    impl Walker {
+        pub fn schedule(&mut self, name: &str) -> Result<()> {
+            if self.visited.contains(name) {
+                bail!("Recursive definition found for {}", name);
+            }
+            self.todos.insert(name.to_string());
+            Ok(())
+        }
+
+        pub fn next(&mut self) -> Option<String> {
+            let name = self.todos.iter().next().cloned();
+
+            if let Some(name) = &name {
+                self.todos.remove(name);
+                assert!(self.visited.insert(name.to_string()));
+            }
+
+            name
+        }
+    }
+
+    #[derive(Default)]
+    struct State {
+        blocks: Walker,
+        fieldsets: Walker,
+        enums: Walker,
+    }
+
+    let mut state = State::default();
+    state.blocks.schedule(block_name)?;
+
+    while let Some(block_name) = state.blocks.next() {
+        let block = ir
+            .blocks
+            .get(&block_name)
+            .ok_or_else(|| anyhow!("Failed to find reference to block {}", block_name))?;
+
+        if let Some(extends) = &block.extends {
+            state.blocks.schedule(extends)?;
+        }
+
+        for item in block.items.iter() {
+            match &item.inner {
+                ir::BlockItemInner::Block(block_item_block) => {
+                    state.blocks.schedule(&block_item_block.block)?
+                }
+                ir::BlockItemInner::Register(register) => {
+                    if let Some(fieldset) = &register.fieldset {
+                        state.fieldsets.schedule(fieldset)?;
+                    }
+                }
+            }
+        }
+    }
+
+    while let Some(fieldset_name) = state.fieldsets.next() {
+        let fieldset = ir
+            .fieldsets
+            .get(&fieldset_name)
+            .ok_or_else(|| anyhow!("Failed to find reference to fieldset {}", fieldset_name))?;
+
+        if let Some(extends) = &fieldset.extends {
+            state.fieldsets.schedule(extends)?;
+        }
+
+        for item in fieldset.fields.iter() {
+            if let Some(enumm) = &item.enumm {
+                state.enums.schedule(enumm)?;
+            }
+        }
+    }
+
+    let mut result = IR::new();
+    result.blocks = ir
+        .blocks
+        .iter()
+        .filter(|(name, _)| state.blocks.visited.contains(*name))
+        .map(|(name, item)| (name.clone(), item.clone()))
+        .collect();
+
+    result.fieldsets = ir
+        .fieldsets
+        .iter()
+        .filter(|(name, _)| state.fieldsets.visited.contains(*name))
+        .map(|(name, item)| (name.clone(), item.clone()))
+        .collect();
+
+    result.enums = ir
+        .enums
+        .iter()
+        .filter(|(name, _)| state.enums.todos.contains(*name)) // Note we have not visited the enums
+        .map(|(name, item)| (name.clone(), item.clone()))
+        .collect();
+
+    Ok(result)
 }

--- a/src/commands/extract_peripheral.rs
+++ b/src/commands/extract_peripheral.rs
@@ -1,5 +1,5 @@
 use crate::commands::{load_svd, ExtractShared};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use std::io::stdout;
 
@@ -32,11 +32,12 @@ pub fn extract_peripheral(args: ExtractPeripheral) -> Result<()> {
             .expect("derivedFrom peripheral not found");
     }
 
-    let ir = crate::commands::extract_peripheral(
-        p,
-        &args.extract_shared.transform,
-        args.extract_shared.namespaces,
-    )?;
+    let mut ir = crate::commands::extract_peripheral(p, args.extract_shared.namespaces)?;
+
+    for transform in args.extract_shared.transform.iter() {
+        crate::commands::apply_transform(&mut ir, transform)
+            .with_context(|| format!("Failed to transform {}", transform.display()))?;
+    }
 
     serde_yaml::to_writer(stdout(), &ir).unwrap();
     Ok(())

--- a/src/commands/gen_block.rs
+++ b/src/commands/gen_block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::{GenerateShared, get_generate_opts},
+    commands::{get_generate_opts, GenerateShared},
     generate,
     ir::IR,
 };

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -2,7 +2,7 @@ use crate::commands::{
     apply_transform, clean_up_ir, get_generate_opts, load_svd, GenerateShared, NamespaceMode,
 };
 use crate::{generate, svd2ir};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use clap::Parser;
 use std::fs;
 use std::fs::File;
@@ -35,13 +35,7 @@ pub fn generate(args: Generate) -> Result<()> {
     let svd =
         load_svd(&args.svd).with_context(|| format!("loading svd at {}", args.svd.display()))?;
 
-    let include_regs_vals = match args.namespaces {
-        NamespaceMode::None => bail!("Not allowed to generate code without namespaces"), // TODO perhaps allow
-        NamespaceMode::Block => false,
-        NamespaceMode::BlockWithRegsVals => true,
-    };
-
-    let mut ir = svd2ir::convert_svd(&svd, include_regs_vals)
+    let mut ir = svd2ir::convert_svd(&svd, args.namespaces)
         .with_context(|| format!("converting svd at {}", args.svd.display()))?;
 
     clean_up_ir(&mut ir)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! For when using chiptool as a library, these commands are exposed for ease of use.
 
-use crate::svd2ir::namespace_names;
+use crate::svd2ir::{namespace_names, NamespaceMode};
 use crate::{ir::IR, svd2ir};
 
 use anyhow::{bail, Context, Result};
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use log::*;
 use std::fs;
 use std::io::Read;
@@ -62,41 +62,22 @@ pub struct ExtractShared {
     pub namespaces: NamespaceMode,
 }
 
-#[derive(Clone, Copy, Debug, ValueEnum, Default)]
-pub enum NamespaceMode {
-    #[default]
-    None,
-    Block,
-    BlockWithRegsVals,
-}
-
 fn clean_up_ir(ir: &mut IR) -> Result<(), anyhow::Error> {
     crate::transform::clean_descriptions::CleanDescriptions {}.run(ir)
 }
 
-/// Extract a peripheral from SVD, clean it up and apply specified transform files.
+/// Extract a peripheral from SVD and clean it up.
 ///
 /// Applies final sorting after applying the transform.
 pub fn extract_peripheral(
     p: &svd_parser::svd::Peripheral,
-    transform: &[PathBuf],
     namespace_mode: NamespaceMode,
 ) -> Result<IR, anyhow::Error> {
     let mut ir = IR::new();
     svd2ir::convert_peripheral(&mut ir, p)?;
     clean_up_ir(&mut ir)?;
 
-    // Prepend the SVD peripheral name as IR namespace.
-    match namespace_mode {
-        NamespaceMode::None => (), // Do nothing,
-        NamespaceMode::Block => namespace_names(p, &mut ir, false),
-        NamespaceMode::BlockWithRegsVals => namespace_names(p, &mut ir, true),
-    }
-
-    for transform in transform.iter() {
-        crate::commands::apply_transform(&mut ir, transform)
-            .with_context(|| format!("Failed to transform {}", transform.display()))?;
-    }
+    namespace_names(p, &mut ir, namespace_mode);
 
     // Ensure consistent sort order in the YAML.
     crate::transform::sort::Sort {}.run(&mut ir).unwrap();

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -1,9 +1,9 @@
+use clap::ValueEnum;
 use log::*;
 use std::collections::{BTreeMap, BTreeSet};
 use svd_parser::svd::{self, PeripheralInfo};
 
-use crate::util;
-use crate::{ir::*, transform};
+use crate::{ir::*, transform, util};
 
 #[derive(Debug)]
 struct ProtoBlock {
@@ -25,6 +25,13 @@ struct ProtoEnum {
     name: Vec<String>,
     bit_size: u32,
     variants: Vec<svd::EnumeratedValue>,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum NamespaceMode {
+    None,
+    Block,
+    BlockWithRegsVals,
 }
 
 pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()> {
@@ -336,9 +343,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
 }
 
 /// Convert an entire SVD to IR.
-///
-/// Optionally include the extra "regs" and "vals" namespaces for registers and enums.
-pub fn convert_svd(svd: &svd::Device, include_regs_vals: bool) -> anyhow::Result<IR> {
+pub fn convert_svd(svd: &svd::Device, namespace: NamespaceMode) -> anyhow::Result<IR> {
     let mut ir = IR::new();
 
     let mut device = Device {
@@ -407,7 +412,7 @@ pub fn convert_svd(svd: &svd::Device, include_regs_vals: bool) -> anyhow::Result
         if p.derived_from.is_none() {
             let mut pir = IR::new();
             convert_peripheral(&mut pir, p)?;
-            namespace_names(p, &mut pir, include_regs_vals);
+            namespace_names(p, &mut pir, namespace);
             ir.merge(pir);
         }
     }
@@ -415,7 +420,6 @@ pub fn convert_svd(svd: &svd::Device, include_regs_vals: bool) -> anyhow::Result
     ir.devices.insert("".to_string(), device);
 
     transform::sort::Sort {}.run(&mut ir).unwrap();
-    transform::sanitize::Sanitize {}.run(&mut ir).unwrap();
 
     Ok(ir)
 }
@@ -530,25 +534,24 @@ fn block_name(peripheral: &PeripheralInfo) -> String {
 /// Map all IR objects to a block namespace.
 ///
 /// Optionally add the '::regs' for registers and '::vals' for enums submodules.
-pub fn namespace_names(peripheral: &PeripheralInfo, ir: &mut IR, include_regs_vals: bool) {
+pub fn namespace_names(peripheral: &PeripheralInfo, ir: &mut IR, namespace: NamespaceMode) {
     let block_name = block_name(peripheral);
 
-    transform::map_names(ir, |k, s| match k {
-        transform::NameKind::Block => *s = format!("{}::{}", block_name, s),
-        transform::NameKind::Fieldset => {
-            *s = if include_regs_vals {
-                format!("{}::regs::{}", block_name, s)
-            } else {
-                format!("{}::{}", block_name, s)
+    transform::map_names(ir, |k, s| {
+        // Denotes whether to transform the name, and with which (empty) midfix.
+        let transform_midfix: Option<&str> = match k {
+            transform::NameKind::Block => Some(""),
+            transform::NameKind::Fieldset => Some("::regs"),
+            transform::NameKind::Enum => Some("::vals"),
+            _ => None,
+        };
+
+        if let Some(midfix) = transform_midfix {
+            match namespace {
+                NamespaceMode::None => (), // Do nothing.
+                NamespaceMode::Block => *s = format!("{}::{}", block_name, s),
+                NamespaceMode::BlockWithRegsVals => *s = format!("{}{}::{}", block_name, midfix, s),
             }
         }
-        transform::NameKind::Enum => {
-            *s = if include_regs_vals {
-                format!("{}::vals::{}", block_name, s)
-            } else {
-                format!("{}::{}", block_name, s)
-            }
-        }
-        _ => {}
     });
 }


### PR DESCRIPTION
Bigger PR to give extract-all the option to function similarly to generate, in the sense that the IR is extracted first before applying the transforms. The 'old' behaviour of first extracting per peripheral is still the default.