### PR TITLE
Make transform::common public for use as a library

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -212,7 +212,7 @@ fn remap_names<T>(
     Ok(())
 }
 
-mod common;
+pub mod common;
 
 macro_rules! transforms {
     ($($mod:ident::$struct:ident,)*) => {


### PR DESCRIPTION
As the transforms themselves are already part of the public api, we probably also need to make their arguments (RegexSet mostly) public for them to be used.