### PR TITLE
Add SanitizeV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "convert_case",
  "env_logger",
  "inflections",
  "log",
@@ -129,6 +130,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "env_filter"
@@ -427,6 +437,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }
 env_logger = "0.11.1"
+convert_case = "0.11"
 inflections = "1.1"
 log = { version = "~0.4", features = ["std"] }
 quote = "1.0"

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 use crate::ir::*;
-use crate::util::{self, StringExt};
+use crate::util;
 
 use super::{sorted, with_defmt_cfg_attr};
 
@@ -34,7 +34,7 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
         }
         pos += 1;
 
-        let name_uc = Ident::new(&i.name.to_sanitized_upper_case(), span);
+        let name_uc = Ident::new(&i.name, span);
         let description = format!(
             "{} - {}",
             i.value,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -235,6 +235,7 @@ macro_rules! transforms {
 
 transforms!(
     sanitize::Sanitize,
+    sanitizev2::SanitizeV2,
     sort::Sort,
     add::Add,
     add_enum_variants::AddEnumVariants,

--- a/src/transform/sanitize.rs
+++ b/src/transform/sanitize.rs
@@ -1,6 +1,7 @@
+use inflections::Inflect;
 use serde::{Deserialize, Serialize};
 
-use crate::util::StringExt;
+use crate::util::sanitize_ident;
 
 use super::{map_names, NameKind, IR};
 
@@ -48,7 +49,7 @@ fn sanitize_path(p: &str) -> String {
         .join("::")
 }
 
-fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
+pub(crate) fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
     use std::collections::BTreeMap;
 
     let mut seen: BTreeMap<(String, u64), crate::ir::EnumVariant> = BTreeMap::new();
@@ -75,7 +76,7 @@ fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
     enumm.variants = new_variants;
 }
 
-fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
+pub(crate) fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
     use std::collections::BTreeMap;
 
     let mut name_counts: BTreeMap<String, usize> = BTreeMap::new();
@@ -90,5 +91,25 @@ fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
             // increment new name to catch cascading name collisons
             *name_counts.entry(v.name.clone()).or_insert(0) += 1;
         }
+    }
+}
+
+trait StringExt {
+    fn to_sanitized_pascal_case(&self) -> String;
+    fn to_sanitized_constant_case(&self) -> String;
+    fn to_sanitized_snake_case(&self) -> String;
+}
+
+impl StringExt for str {
+    fn to_sanitized_snake_case(&self) -> String {
+        sanitize_ident(self.to_snake_case())
+    }
+
+    fn to_sanitized_constant_case(&self) -> String {
+        sanitize_ident(self.to_constant_case())
+    }
+
+    fn to_sanitized_pascal_case(&self) -> String {
+        sanitize_ident(self.to_pascal_case())
     }
 }

--- a/src/transform/sanitizev2.rs
+++ b/src/transform/sanitizev2.rs
@@ -1,0 +1,84 @@
+use convert_case::{Boundary, Casing};
+use serde::{Deserialize, Serialize};
+
+use crate::util::sanitize_ident;
+
+use super::{map_names, NameKind, IR};
+
+/// Sanitize names and paths of all objects, using proper casing and stripping keywords.
+///
+/// # Changes relative to Sanitize(V1):
+/// * Uses PascalCase for enum variants instead of CONSTANT_CASE
+/// * Uses PascalCase for interrupts (which are enum variants under the hood) instead of CONSTANT_CASE and later UPPER CASE in the generator.
+/// * Uses convert_case crate instead of Inflections to have a fine control over word boundaries
+///   such that the operations are more consistent.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SanitizeV2 {}
+
+impl SanitizeV2 {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        map_names(ir, |k, p| match k {
+            NameKind::Device => *p = sanitize_path(p),
+            NameKind::DevicePeripheral => *p = p.to_sanitized_constant_case().to_string(),
+            NameKind::DeviceInterrupt => *p = p.to_sanitized_pascal_case().to_string(),
+            NameKind::Block => *p = sanitize_path(p),
+            NameKind::Fieldset => *p = sanitize_path(p),
+            NameKind::Enum => *p = sanitize_path(p),
+            NameKind::BlockItem => *p = p.to_sanitized_snake_case().to_string(),
+            NameKind::Field => *p = p.to_sanitized_snake_case().to_string(),
+            NameKind::EnumVariant => *p = p.to_sanitized_pascal_case().to_string(),
+        });
+
+        // After sanitizing names, merge duplicate enum variants with the same name and value
+        for (_, enumm) in ir.enums.iter_mut() {
+            super::sanitize::merge_duplicate_variants(enumm);
+            // rename duplicate enum variants with the same name but different values
+            super::sanitize::rename_duplicate_variants(enumm);
+        }
+
+        Ok(())
+    }
+}
+
+fn sanitize_path(p: &str) -> String {
+    let v = p.split("::").collect::<Vec<_>>();
+    let len = v.len();
+    v.into_iter()
+        .enumerate()
+        .map(|(i, s)| {
+            if i == len - 1 {
+                s.to_sanitized_pascal_case()
+            } else {
+                s.to_sanitized_snake_case()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+fn sanitize_with_case(str: &str, case: convert_case::Case) -> String {
+    sanitize_ident(
+        str.remove_boundaries(&[Boundary::LowerDigit, Boundary::UpperDigit])
+            .to_case(case),
+    )
+}
+
+trait StringExt {
+    fn to_sanitized_pascal_case(&self) -> String;
+    fn to_sanitized_constant_case(&self) -> String;
+    fn to_sanitized_snake_case(&self) -> String;
+}
+
+impl StringExt for str {
+    fn to_sanitized_snake_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Snake)
+    }
+
+    fn to_sanitized_constant_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Constant)
+    }
+
+    fn to_sanitized_pascal_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Pascal)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use inflections::Inflect;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::str::FromStr;
@@ -19,7 +18,7 @@ static KEYWORDS: &[&str] = &[
 ];
 
 /// Make `s` a valid identifier, making the minimal changes (no case changes)
-fn sanitize_ident(s: String) -> String {
+pub(crate) fn sanitize_ident(s: String) -> String {
     let mut s = s.replace(INVALID_CHARS, "");
     if KEYWORDS.contains(&&*s) {
         s.push('_');
@@ -28,31 +27,6 @@ fn sanitize_ident(s: String) -> String {
         format!("_{}", s)
     } else {
         s
-    }
-}
-
-pub trait StringExt {
-    fn to_sanitized_pascal_case(&self) -> String;
-    fn to_sanitized_upper_case(&self) -> String;
-    fn to_sanitized_constant_case(&self) -> String;
-    fn to_sanitized_snake_case(&self) -> String;
-}
-
-impl StringExt for str {
-    fn to_sanitized_snake_case(&self) -> String {
-        sanitize_ident(self.to_snake_case())
-    }
-
-    fn to_sanitized_upper_case(&self) -> String {
-        sanitize_ident(self.to_upper_case())
-    }
-
-    fn to_sanitized_constant_case(&self) -> String {
-        sanitize_ident(self.to_constant_case())
-    }
-
-    fn to_sanitized_pascal_case(&self) -> String {
-        sanitize_ident(self.to_pascal_case())
     }
 }
 


### PR DESCRIPTION
The current Sanitize has some issues with consistency, internally and with respect to the language. Fixing this will result in a different extraction and generate behaviour. Because we do not necessarily want to force changes upon the users of chiptool, I propose we add an alternative and in my opinion better transform step which users can opt into.

Firstly, running Sanitize multiple times results in some identifiers changing (thus the operation is not transitive). Previously Sanitize was called in various steps around the code. Now that has been removed, in order to get the same behaviour, the Sanitize transform needs to be called at least twice.

For example, `EDMA0_TCD0` -> `Edma0Tcd0` -> `Edma0tcd0`.

The underlying issue is that the `inflections` crate determines word boundaries different between these stages. This crate seems currently orphaned (though a PR might be merged). The `convert_case` crate however allows us the specifically define the desired behaviour. Hence SanitizeV2 uses this instead with a specific word boundary defined.

Secondly as already requested in #110 chiptool generates enum variants as CONSTANT_CASE. This is not the typical standard in Rust. I propose we change this to the standard PascalCase.

# Changes relative to Sanitize(V1):
* Uses PascalCase for enum variants instead of CONSTANT_CASE
* Uses PascalCase for interrupts (which are enum variants under the hood) instead of CONSTANT_CASE and later UPPER CASE in the generator.
* Uses convert_case crate instead of Inflections to have a fine control over word boundaries such that the operations are more consistent.