### PR TITLE
Detect duplicate renames

### DIFF
--- a/src/transform/common.rs
+++ b/src/transform/common.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::ir::*;
 
@@ -341,4 +342,52 @@ impl CheckLevel {
             Ok(())
         }
     }
+}
+/// Return `true` if `old_name` can be renamed to
+/// `new_name` without duplicates.
+///
+/// `renames` should represent the state for `new_name` in
+/// the current scope
+pub(crate) fn can_rename<Fmt>(
+    error_on_duplicate: bool,
+    renames: &mut HashMap<String, Option<String>>,
+    new_name: &str,
+    old_name: &str,
+    fmt: Fmt,
+) -> bool
+where
+    Fmt: Fn(String) -> String,
+{
+    match renames.entry(new_name.to_string()) {
+        // Not duplicate
+        Entry::Vacant(e) => {
+            e.insert(Some(old_name.to_string()));
+            true
+        }
+        Entry::Occupied(mut e) => {
+            let level = error_on_duplicate
+                .then_some(log::Level::Error)
+                .unwrap_or(log::Level::Warn);
+
+            let log = |field: String| {
+                log::log!(
+                    level,
+                    "Renaming {} failed: reused new name {new_name}",
+                    fmt(field)
+                );
+            };
+
+            // Log the name of the first field for good measure, and get rid of it
+            if let Some(prev) = e.get_mut().take() {
+                log(prev)
+            }
+
+            log(old_name.to_string());
+            false
+        }
+    }
+}
+
+pub(crate) fn get_true() -> bool {
+    true
 }

--- a/src/transform/rename_fields.rs
+++ b/src/transform/rename_fields.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -8,18 +10,34 @@ pub struct RenameFields {
     pub fieldset: RegexSet,
     pub from: RegexSet,
     pub to: String,
+    #[serde(default = "get_true")]
+    pub error_on_duplicate: bool,
 }
 
 impl RenameFields {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        let mut renames = HashMap::new();
+        let mut had_duplicate = false;
+
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
             let fs = ir.fieldsets.get_mut(&id).unwrap();
+            let renames = renames.entry(id.clone()).or_default();
+
+            let fmt = |field| format!("field {field} in fieldset {id}");
+
             for f in &mut fs.fields {
                 if let Some(name) = match_expand(&f.name, &self.from, &self.to) {
+                    had_duplicate |=
+                        !can_rename(self.error_on_duplicate, renames, &name, &f.name, fmt);
                     f.name = name;
                 }
             }
         }
+
+        if had_duplicate && self.error_on_duplicate {
+            anyhow::bail!("Duplicate use of new names");
+        }
+
         Ok(())
     }
 }

--- a/src/transform/rename_interrupts.rs
+++ b/src/transform/rename_interrupts.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -7,17 +9,31 @@ use crate::ir::*;
 pub struct RenameInterrupts {
     pub from: RegexSet,
     pub to: String,
+    #[serde(default = "get_true")]
+    pub error_on_duplicate: bool,
 }
 
 impl RenameInterrupts {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
-        for d in ir.devices.values_mut() {
+        let mut had_duplicate = false;
+
+        for (dev_name, d) in ir.devices.iter_mut() {
+            let mut renames = HashMap::new();
+            let fmt = |itr| format!("interrupt {itr} for device {dev_name}");
+
             for i in &mut d.interrupts {
                 if let Some(name) = match_expand(&i.name, &self.from, &self.to) {
+                    had_duplicate |=
+                        !can_rename(self.error_on_duplicate, &mut renames, &name, &i.name, fmt);
                     i.name = name;
                 }
             }
         }
+
+        if had_duplicate && self.error_on_duplicate {
+            anyhow::bail!("Failed to rename interrupts");
+        }
+
         Ok(())
     }
 }

--- a/src/transform/rename_peripherals.rs
+++ b/src/transform/rename_peripherals.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -7,17 +9,31 @@ use crate::ir::*;
 pub struct RenamePeripherals {
     pub from: RegexSet,
     pub to: String,
+    #[serde(default = "get_true")]
+    pub error_on_duplicate: bool,
 }
 
 impl RenamePeripherals {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
-        for d in ir.devices.values_mut() {
+        let mut had_duplicate = false;
+
+        for (dev_name, d) in ir.devices.iter_mut() {
+            let mut renames = HashMap::new();
+            let fmt = |peri| format!("peripheral {peri} for device {dev_name}");
+
             for p in &mut d.peripherals {
                 if let Some(name) = match_expand(&p.name, &self.from, &self.to) {
+                    had_duplicate |=
+                        !can_rename(self.error_on_duplicate, &mut renames, &name, &p.name, fmt);
                     p.name = name;
                 }
             }
         }
+
+        if had_duplicate && self.error_on_duplicate {
+            anyhow::bail!("Failed to rename peripherals");
+        }
+
         Ok(())
     }
 }

--- a/src/transform/rename_registers.rs
+++ b/src/transform/rename_registers.rs
@@ -1,7 +1,5 @@
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use log::Level;
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -16,48 +14,22 @@ pub struct RenameRegisters {
     pub error_on_duplicate: bool,
 }
 
-fn get_true() -> bool {
-    true
-}
-
 impl RenameRegisters {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
-        // Map blocks to new names that have been used, and the first
-        // field that was renamed to that new name.
-        let mut renames: HashMap<_, HashMap<String, Option<String>>> = HashMap::new();
+        let mut renames = HashMap::new();
         let mut had_duplicate = false;
 
         for id in match_all(ir.blocks.keys().cloned(), &self.block) {
             let b = ir.blocks.get_mut(&id).unwrap();
             let renames = renames.entry(id.clone()).or_default();
 
+            let fmt = |field| format!("register {field} in block {id}");
+
             for i in b.items.iter_mut() {
                 if let Some(name) = match_expand(&i.name, &self.from, &self.to) {
-                    match renames.entry(name.clone()) {
-                        // Not duplicate
-                        Entry::Vacant(e) => {
-                            e.insert(Some(i.name.clone()));
-                            i.name = name.clone();
-                        }
-                        Entry::Occupied(mut e) => {
-                            let level = self
-                                .error_on_duplicate
-                                .then_some(Level::Error)
-                                .unwrap_or(Level::Warn);
-
-                            let log = |reg: &str| {
-                                log::log!(level, "Renaming register {reg} in block {id} failed: reused new name {name}");
-                            };
-
-                            // Log the name of the first field for good measure, and get rid of it
-                            if let Some(prev) = e.get_mut().take() {
-                                log(&prev)
-                            }
-
-                            log(&i.name);
-                            had_duplicate = true;
-                        }
-                    }
+                    had_duplicate |=
+                        !can_rename(self.error_on_duplicate, renames, &name, &i.name, fmt);
+                    i.name = name;
                 }
             }
         }

--- a/src/transform/rename_registers.rs
+++ b/src/transform/rename_registers.rs
@@ -1,3 +1,7 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+use log::Level;
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -8,18 +12,60 @@ pub struct RenameRegisters {
     pub block: RegexSet,
     pub from: RegexSet,
     pub to: String,
+    #[serde(default = "get_true")]
+    pub error_on_duplicate: bool,
+}
+
+fn get_true() -> bool {
+    true
 }
 
 impl RenameRegisters {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        // Map blocks to new names that have been used, and the first
+        // field that was renamed to that new name.
+        let mut renames: HashMap<_, HashMap<String, Option<String>>> = HashMap::new();
+        let mut had_duplicate = false;
+
         for id in match_all(ir.blocks.keys().cloned(), &self.block) {
             let b = ir.blocks.get_mut(&id).unwrap();
-            for i in &mut b.items {
+            let renames = renames.entry(id.clone()).or_default();
+
+            for i in b.items.iter_mut() {
                 if let Some(name) = match_expand(&i.name, &self.from, &self.to) {
-                    i.name = name;
+                    match renames.entry(name.clone()) {
+                        // Not duplicate
+                        Entry::Vacant(e) => {
+                            e.insert(Some(i.name.clone()));
+                            i.name = name.clone();
+                        }
+                        Entry::Occupied(mut e) => {
+                            let level = self
+                                .error_on_duplicate
+                                .then_some(Level::Error)
+                                .unwrap_or(Level::Warn);
+
+                            let log = |reg: &str| {
+                                log::log!(level, "Renaming register {reg} in block {id} failed: reused new name {name}");
+                            };
+
+                            // Log the name of the first field for good measure, and get rid of it
+                            if let Some(prev) = e.get_mut().take() {
+                                log(&prev)
+                            }
+
+                            log(&i.name);
+                            had_duplicate = true;
+                        }
+                    }
                 }
             }
         }
+
+        if had_duplicate && self.error_on_duplicate {
+            anyhow::bail!("Duplicate use of new names");
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Currently, chiptool will happily rename multiple registers and fields to the same value.

This PR adds support for telling the user that this isn't going to work, with a way to opt-out