### PR TITLE
sanitize: use PascalCase for enums, switch from `inflections` to `convert_case`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "convert_case",
  "env_logger",
- "inflections",
  "log",
  "proc-macro2",
  "quote",
@@ -131,6 +131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,12 +189,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
-
-[[package]]
-name = "inflections"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -427,6 +430,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }
 env_logger = "0.11.1"
-inflections = "1.1"
+convert_case = "0.11"
 log = { version = "~0.4", features = ["std"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
 use crate::ir::*;
-use crate::util::{self, StringExt};
+use crate::util;
 
 use super::{sorted, with_defmt_cfg_attr};
 
@@ -34,7 +34,7 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
         }
         pos += 1;
 
-        let name_uc = Ident::new(&i.name.to_sanitized_upper_case(), span);
+        let name_uc = Ident::new(&i.name, span);
         let description = format!(
             "{} - {}",
             i.value,

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -3,7 +3,7 @@ use log::*;
 use std::collections::{BTreeMap, BTreeSet};
 use svd_parser::svd::{self, PeripheralInfo};
 
-use crate::{ir::*, transform, util};
+use crate::{ir::*, transform};
 
 #[derive(Debug)]
 struct ProtoBlock {
@@ -57,7 +57,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
 
                 if let Some(fields) = &r.fields {
                     let mut fieldset_name = block.name.clone();
-                    fieldset_name.push(util::replace_suffix(&r.name, ""));
+                    fieldset_name.push(replace_suffix(&r.name, ""));
                     fieldsets.push(ProtoFieldset {
                         name: fieldset_name.clone(),
                         description: r.description.clone(),
@@ -74,7 +74,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                         let mut enum_write = None;
                         let mut enum_readwrite = None;
 
-                        let field_name = util::replace_suffix(&f.name, "");
+                        let field_name = replace_suffix(&f.name, "");
 
                         for e in &f.enumerated_values {
                             let e = if let Some(derived_from) = &e.derived_from {
@@ -193,7 +193,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
 
                     let fieldset_name = if r.fields.is_some() {
                         let mut fieldset_name = proto.name.clone();
-                        fieldset_name.push(util::replace_suffix(&r.name, ""));
+                        fieldset_name.push(replace_suffix(&r.name, ""));
                         Some(fieldset_names.get(&fieldset_name).unwrap().clone())
                     } else {
                         None
@@ -218,7 +218,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                     };
 
                     let block_item = BlockItem {
-                        name: util::replace_suffix(&r.name, ""),
+                        name: replace_suffix(&r.name, ""),
                         description: r.description.clone(),
                         array,
                         byte_offset: r.address_offset,
@@ -237,7 +237,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                         continue;
                     }
 
-                    let cname = util::replace_suffix(&c.name, "");
+                    let cname = replace_suffix(&c.name, "");
 
                     let array = if let svd::Cluster::Array(_, dim) = c {
                         Some(Array::Regular(RegularArray {
@@ -249,7 +249,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                     };
 
                     let mut block_name = proto.name.clone();
-                    block_name.push(util::replace_suffix(&c.name, ""));
+                    block_name.push(replace_suffix(&c.name, ""));
                     let block_name = block_names.get(&block_name).unwrap().clone();
 
                     block.items.push(BlockItem {
@@ -290,7 +290,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                 None
             };
 
-            let field_name = util::replace_suffix(&f.name, "");
+            let field_name = replace_suffix(&f.name, "");
 
             let mut field = Field {
                 name: field_name.clone(),
@@ -468,7 +468,7 @@ fn collect_blocks(
             }
 
             let mut block_name = block_name.clone();
-            block_name.push(util::replace_suffix(&c.name, ""));
+            block_name.push(replace_suffix(&c.name, ""));
             collect_blocks(out, block_name, c.description.clone(), &c.children);
         }
     }
@@ -554,4 +554,12 @@ pub fn namespace_names(peripheral: &PeripheralInfo, ir: &mut IR, namespace: Name
             }
         }
     });
+}
+
+pub fn replace_suffix(name: &str, suffix: &str) -> String {
+    if name.contains("[%s]") {
+        name.replace("[%s]", suffix)
+    } else {
+        name.replace("%s", suffix)
+    }
 }

--- a/src/transform/sanitize.rs
+++ b/src/transform/sanitize.rs
@@ -1,9 +1,9 @@
+use convert_case::{Boundary, Casing};
 use serde::{Deserialize, Serialize};
-
-use crate::util::StringExt;
 
 use super::{map_names, NameKind, IR};
 
+/// Sanitize names and paths of all objects, using proper casing and stripping keywords.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Sanitize {}
 
@@ -18,7 +18,7 @@ impl Sanitize {
             NameKind::Enum => *p = sanitize_path(p),
             NameKind::BlockItem => *p = p.to_sanitized_snake_case().to_string(),
             NameKind::Field => *p = p.to_sanitized_snake_case().to_string(),
-            NameKind::EnumVariant => *p = p.to_sanitized_constant_case().to_string(),
+            NameKind::EnumVariant => *p = p.to_sanitized_pascal_case().to_string(),
         });
 
         // After sanitizing names, merge duplicate enum variants with the same name and value
@@ -48,7 +48,14 @@ fn sanitize_path(p: &str) -> String {
         .join("::")
 }
 
-fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
+fn sanitize_with_case(str: &str, case: convert_case::Case) -> String {
+    sanitize_ident(
+        str.remove_boundaries(&[Boundary::LowerDigit, Boundary::UpperDigit])
+            .to_case(case),
+    )
+}
+
+pub(crate) fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
     use std::collections::BTreeMap;
 
     let mut seen: BTreeMap<(String, u64), crate::ir::EnumVariant> = BTreeMap::new();
@@ -75,7 +82,7 @@ fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {
     enumm.variants = new_variants;
 }
 
-fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
+pub(crate) fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
     use std::collections::BTreeMap;
 
     let mut name_counts: BTreeMap<String, usize> = BTreeMap::new();
@@ -90,5 +97,50 @@ fn rename_duplicate_variants(enumm: &mut crate::ir::Enum) {
             // increment new name to catch cascading name collisons
             *name_counts.entry(v.name.clone()).or_insert(0) += 1;
         }
+    }
+}
+
+trait StringExt {
+    fn to_sanitized_pascal_case(&self) -> String;
+    fn to_sanitized_constant_case(&self) -> String;
+    fn to_sanitized_snake_case(&self) -> String;
+}
+
+impl StringExt for str {
+    fn to_sanitized_snake_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Snake)
+    }
+
+    fn to_sanitized_constant_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Constant)
+    }
+
+    fn to_sanitized_pascal_case(&self) -> String {
+        sanitize_with_case(self, convert_case::Case::Pascal)
+    }
+}
+
+/// List of chars that some vendors use in their peripheral/field names but
+/// that are not valid in Rust ident
+const INVALID_CHARS: &[char] = &['(', ')', '[', ']', '/', ' ', '-'];
+
+static KEYWORDS: &[&str] = &[
+    "abstract", "as", "async", "await", "become", "box", "break", "const", "continue", "crate",
+    "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
+    "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",
+    "return", "self", "Self", "static", "struct", "super", "trait", "true", "try", "type",
+    "typeof", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+];
+
+/// Make `s` a valid identifier, making the minimal changes (no case changes)
+pub(crate) fn sanitize_ident(s: String) -> String {
+    let mut s = s.replace(INVALID_CHARS, "");
+    if KEYWORDS.contains(&&*s) {
+        s.push('_');
+        s
+    } else if s.starts_with(char::is_numeric) {
+        format!("_{}", s)
+    } else {
+        s
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,60 +1,9 @@
 use anyhow::{anyhow, Result};
-use inflections::Inflect;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::str::FromStr;
 
 pub const BITS_PER_BYTE: u32 = 8;
-
-/// List of chars that some vendors use in their peripheral/field names but
-/// that are not valid in Rust ident
-const INVALID_CHARS: &[char] = &['(', ')', '[', ']', '/', ' ', '-'];
-
-static KEYWORDS: &[&str] = &[
-    "abstract", "as", "async", "await", "become", "box", "break", "const", "continue", "crate",
-    "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
-    "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",
-    "return", "self", "Self", "static", "struct", "super", "trait", "true", "try", "type",
-    "typeof", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
-];
-
-/// Make `s` a valid identifier, making the minimal changes (no case changes)
-fn sanitize_ident(s: String) -> String {
-    let mut s = s.replace(INVALID_CHARS, "");
-    if KEYWORDS.contains(&&*s) {
-        s.push('_');
-        s
-    } else if s.starts_with(char::is_numeric) {
-        format!("_{}", s)
-    } else {
-        s
-    }
-}
-
-pub trait StringExt {
-    fn to_sanitized_pascal_case(&self) -> String;
-    fn to_sanitized_upper_case(&self) -> String;
-    fn to_sanitized_constant_case(&self) -> String;
-    fn to_sanitized_snake_case(&self) -> String;
-}
-
-impl StringExt for str {
-    fn to_sanitized_snake_case(&self) -> String {
-        sanitize_ident(self.to_snake_case())
-    }
-
-    fn to_sanitized_upper_case(&self) -> String {
-        sanitize_ident(self.to_upper_case())
-    }
-
-    fn to_sanitized_constant_case(&self) -> String {
-        sanitize_ident(self.to_constant_case())
-    }
-
-    fn to_sanitized_pascal_case(&self) -> String {
-        sanitize_ident(self.to_pascal_case())
-    }
-}
 
 pub fn respace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
@@ -81,14 +30,6 @@ pub fn escape_brackets(s: &str) -> String {
                 acc + "\\]" + x
             }
         })
-}
-
-pub fn replace_suffix(name: &str, suffix: &str) -> String {
-    if name.contains("[%s]") {
-        name.replace("[%s]", suffix)
-    } else {
-        name.replace("%s", suffix)
-    }
 }
 
 pub fn hex_str(n: u64) -> String {


### PR DESCRIPTION
Co-Authored-By: Dario Nieuwenhuis <dirbaio@dirbaio.net>
