### PR TITLE
Add legacy sanitize cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "clap",
  "convert_case",
  "env_logger",
+ "inflections",
  "log",
  "proc-macro2",
  "quote",
@@ -189,6 +190,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ svd-parser = { git = "https://github.com/embassy-rs/svd.git", rev = "f4f192d0839
 #svd-parser = { path = "./svd/svd-parser", features = ["derive-from", "expand"] }
 # Development has stopped for `serde_yaml`
 serde_yaml = "=0.9.34-deprecated"
+inflections = "1.1.1"

--- a/src/transform/sanitize.rs
+++ b/src/transform/sanitize.rs
@@ -1,9 +1,10 @@
 use convert_case::{Boundary, Casing};
+use inflections::Inflect;
 use serde::{Deserialize, Serialize};
 
 use super::{map_names, NameKind, IR};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum SanitizeCase {
     None,
     Snake,
@@ -14,34 +15,52 @@ pub enum SanitizeCase {
     UpperFlat,
     /// Path: `snake::Pascal`
     PathSnakePascal,
+
+    ConstantLegacy,
+    SnakeLegacy,
+    PascalLegacy,
+    PathSnakeLegacy,
 }
 
 impl SanitizeCase {
     fn apply(self, s: &str) -> String {
-        match self {
-            SanitizeCase::None => s.to_string(),
-            SanitizeCase::Snake => sanitize_with_case(s, convert_case::Case::Snake),
-            SanitizeCase::Constant => sanitize_with_case(s, convert_case::Case::Constant),
-            SanitizeCase::Pascal => sanitize_with_case(s, convert_case::Case::Pascal),
-            SanitizeCase::Camel => sanitize_with_case(s, convert_case::Case::Camel),
-            SanitizeCase::Flat => sanitize_with_case(s, convert_case::Case::Flat),
-            SanitizeCase::UpperFlat => sanitize_with_case(s, convert_case::Case::UpperFlat),
-            SanitizeCase::PathSnakePascal => {
+        let case = match self {
+            SanitizeCase::None => return s.to_string(),
+            SanitizeCase::Snake => convert_case::Case::Snake,
+            SanitizeCase::Constant => convert_case::Case::Constant,
+            SanitizeCase::Pascal => convert_case::Case::Pascal,
+            SanitizeCase::Camel => convert_case::Case::Camel,
+            SanitizeCase::Flat => convert_case::Case::Flat,
+            SanitizeCase::UpperFlat => convert_case::Case::UpperFlat,
+            SanitizeCase::PathSnakePascal | SanitizeCase::PathSnakeLegacy => {
+                let (pascal, snake) = if self == SanitizeCase::PathSnakeLegacy {
+                    (SanitizeCase::PascalLegacy, SanitizeCase::SnakeLegacy)
+                } else {
+                    (SanitizeCase::Pascal, SanitizeCase::Snake)
+                };
+
                 let v = s.split("::").collect::<Vec<_>>();
                 let len = v.len();
-                v.into_iter()
+                return v
+                    .into_iter()
                     .enumerate()
                     .map(|(i, seg)| {
                         if i == len - 1 {
-                            sanitize_with_case(seg, convert_case::Case::Pascal)
+                            pascal.apply(seg)
                         } else {
-                            sanitize_with_case(seg, convert_case::Case::Snake)
+                            snake.apply(seg)
                         }
                     })
                     .collect::<Vec<_>>()
-                    .join("::")
+                    .join("::");
             }
-        }
+            SanitizeCase::ConstantLegacy => return sanitize_ident(s.to_constant_case()),
+            SanitizeCase::SnakeLegacy => return sanitize_ident(s.to_snake_case()),
+            SanitizeCase::PascalLegacy => return sanitize_ident(s.to_pascal_case()),
+        };
+
+        let s = s.remove_boundaries(&Boundary::digits()).to_case(case);
+        sanitize_ident(s)
     }
 }
 
@@ -103,10 +122,6 @@ impl Sanitize {
 
         Ok(())
     }
-}
-
-fn sanitize_with_case(str: &str, case: convert_case::Case) -> String {
-    sanitize_ident(str.remove_boundaries(&Boundary::digits()).to_case(case))
 }
 
 pub(crate) fn merge_duplicate_variants(enumm: &mut crate::ir::Enum) {


### PR DESCRIPTION
Despite the conclusion of "we should just move" in #118  and #124, I am pained by the fact that it was so weirdly difficult to maintain two separate versions without obvious indication what the difference would have been. Also I don't want to do renaming (just because it's boring, even _with_ LLM assistance).

I was also too late/too lazy to write any feedback before the whole thing got merged :P

Making it configurable was easy enough, and by doing a bit more composition and a bit less nesting doesn't require sending a `SanitizeVersion` absolutely everywhere. It also becomes quite obvious what the difference between the two is.

Since this doesn't solve any of the actual problems raised in the #118 and just makes it configurable, I'm perfectly fine with just closing this. But wanted to put it up in case it's desireable, somehow