### PR TITLE
svd2ir: actually use cache when generating unique names

### DIFF
--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -504,19 +504,37 @@ fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
     let mut res = BTreeMap::new();
     let mut seen = BTreeSet::new();
 
-    let suffix_exists = |n: &[String], i: usize| {
-        names2
-            .iter()
-            .enumerate()
-            .filter(|(j, _)| *j != i)
-            .any(|(_, n2)| n2.ends_with(n))
-    };
     for (i, n) in names2.iter().enumerate() {
-        let j = (0..n.len())
-            .rev()
-            .find(|&j| !suffix_exists(&n[j..], i))
+        // For `n` of length 0 to `n.len()`,
+        // find the first one that does not exist in `names2`
+
+        let mut new_prefix_len = None;
+        for prefix_len in (0..n.len()).rev() {
+            let suffix = &n[prefix_len..];
+
+            let mut suffix_exists = false;
+
+            for (idx, n2) in names2.iter().enumerate() {
+                if idx == i {
+                    continue;
+                }
+
+                if n2.ends_with(suffix) {
+                    suffix_exists = true;
+                    break;
+                }
+            }
+
+            if !suffix_exists {
+                new_prefix_len = Some(prefix_len);
+                break;
+            }
+        }
+
+        let j = new_prefix_len
             .or_else(|| (0..n.len()).rev().find(|&j| !seen.contains(&n[j..])))
             .unwrap();
+
         assert!(res.insert(names[i].clone(), n[j..].join("_")).is_none());
         seen.insert(&n[j..]);
     }

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::ValueEnum;
 use log::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -171,9 +172,9 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
     }
 
     // Make all collected names unique by prefixing with parents' names if needed.
-    let block_names = unique_names(blocks.iter().map(|x| x.name.clone()).collect());
-    let fieldset_names = unique_names(fieldsets.iter().map(|x| x.name.clone()).collect());
-    let enum_names = unique_names(enums.iter().map(|x| x.name.clone()).collect());
+    let block_names = unique_names(blocks.iter().map(|x| x.name.clone()).collect())?;
+    let fieldset_names = unique_names(fieldsets.iter().map(|x| x.name.clone()).collect())?;
+    let enum_names = unique_names(enums.iter().map(|x| x.name.clone()).collect())?;
 
     // Convert blocks
     for proto in &blocks {
@@ -474,7 +475,12 @@ fn collect_blocks(
     }
 }
 
-fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
+/// An iterator yielding successively longer suffixes
+fn suffixes(n: &[String]) -> impl Iterator<Item = &[String]> {
+    (0..n.len()).rev().map(|v| &n[v..])
+}
+
+fn unique_names(names: Vec<Vec<String>>) -> anyhow::Result<BTreeMap<Vec<String>, String>> {
     let names2 = names
         .iter()
         .map(|n| {
@@ -502,30 +508,28 @@ fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
         .collect::<Vec<_>>();
 
     let mut res = BTreeMap::new();
-    let mut seen = BTreeSet::new();
+    let mut suffix_occurrences = BTreeMap::new();
 
-    for (i, (original, n)) in names.iter().zip(names2.iter()).enumerate() {
-        // An iterator yielding successively longer suffixes
-        let mut suffixes = (0..n.len()).rev().map(|v| &n[v..]);
+    for name in names2.iter() {
+        for suffix in suffixes(&name) {
+            let entry = suffix_occurrences.entry(suffix).or_insert(0);
+            *entry += 1;
+        }
+    }
 
-        let shortest_unique_suffix = suffixes.clone().find(|suffix| {
-            let suffix_is_unique = !names2
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, v)| (idx != i).then_some(v))
-                .any(|n2| n2.ends_with(suffix));
-
+    for (original, n) in names.iter().zip(names2.iter()) {
+        let shortest_unique_suffix = suffixes(n).find(|suffix| {
+            let suffix_is_unique = *suffix_occurrences.get(suffix).unwrap() == 1;
             suffix_is_unique
         });
 
-        let suffix = shortest_unique_suffix
-            .or_else(|| suffixes.find(|suffix| !seen.contains(suffix)))
-            .unwrap();
+        let suffix = shortest_unique_suffix.with_context(|| {
+            format!("Failed to find unique name for {:?}. n: {:?}", original, n)
+        })?;
 
         assert!(res.insert(original.clone(), suffix.join("_")).is_none());
-        seen.insert(suffix);
     }
-    res
+    Ok(res)
 }
 
 /// Derive a canonical block name from a SVD peripheral.

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -504,23 +504,25 @@ fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
     let mut res = BTreeMap::new();
     let mut seen = BTreeSet::new();
 
-    for (i, n) in names2.iter().enumerate() {
+    for (i, (original, n)) in names.iter().zip(names2.iter()).enumerate() {
         // An iterator yielding successively longer suffixes
         let mut suffixes = (0..n.len()).rev().map(|v| &n[v..]);
 
         let shortest_unique_suffix = suffixes.clone().find(|suffix| {
-            !names2
+            let suffix_is_unique = !names2
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, v)| (idx != i).then_some(v))
-                .any(|n2| n2.ends_with(suffix))
+                .any(|n2| n2.ends_with(suffix));
+
+            suffix_is_unique
         });
 
         let suffix = shortest_unique_suffix
             .or_else(|| suffixes.find(|suffix| !seen.contains(suffix)))
             .unwrap();
 
-        assert!(res.insert(names[i].clone(), suffix.join("_")).is_none());
+        assert!(res.insert(original.clone(), suffix.join("_")).is_none());
         seen.insert(suffix);
     }
     res

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -505,38 +505,23 @@ fn unique_names(names: Vec<Vec<String>>) -> BTreeMap<Vec<String>, String> {
     let mut seen = BTreeSet::new();
 
     for (i, n) in names2.iter().enumerate() {
-        // For `n` of length 0 to `n.len()`,
-        // find the first one that does not exist in `names2`
+        // An iterator yielding successively longer suffixes
+        let mut suffixes = (0..n.len()).rev().map(|v| &n[v..]);
 
-        let mut new_prefix_len = None;
-        for prefix_len in (0..n.len()).rev() {
-            let suffix = &n[prefix_len..];
+        let shortest_unique_suffix = suffixes.clone().find(|suffix| {
+            !names2
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, v)| (idx != i).then_some(v))
+                .any(|n2| n2.ends_with(suffix))
+        });
 
-            let mut suffix_exists = false;
-
-            for (idx, n2) in names2.iter().enumerate() {
-                if idx == i {
-                    continue;
-                }
-
-                if n2.ends_with(suffix) {
-                    suffix_exists = true;
-                    break;
-                }
-            }
-
-            if !suffix_exists {
-                new_prefix_len = Some(prefix_len);
-                break;
-            }
-        }
-
-        let j = new_prefix_len
-            .or_else(|| (0..n.len()).rev().find(|&j| !seen.contains(&n[j..])))
+        let suffix = shortest_unique_suffix
+            .or_else(|| suffixes.find(|suffix| !seen.contains(suffix)))
             .unwrap();
 
-        assert!(res.insert(names[i].clone(), n[j..].join("_")).is_none());
-        seen.insert(&n[j..]);
+        assert!(res.insert(names[i].clone(), suffix.join("_")).is_none());
+        seen.insert(suffix);
     }
     res
 }


### PR DESCRIPTION
The previous cache didn't really do anything. Now we actually build a cache and use it to determine whether a suffix is unique.

For the IMXRT118x svd (where one of the `names` passed to `unique_names` has 22k entries), this reduced a `generate` command execution from

    Time (mean ± σ):      3.967 s ±  0.037 s    [User: 3.647 s, System: 0.319 s]
    Range (min … max):    3.927 s …  4.020 s    5 runs
to

    Time (mean ± σ):      2.356 s ±  0.015 s    [User: 2.027 s, System: 0.327 s]
    Range (min … max):    2.340 s …  2.376 s    5 runs