### PR TITLE
Set variants _0 and _1 as useless.

### DIFF
--- a/src/transform/delete_useless_enums.rs
+++ b/src/transform/delete_useless_enums.rs
@@ -35,6 +35,7 @@ impl DeleteUselessEnums {
 }
 
 const USELESS_ZERO_NAMES: &[&str] = &[
+    "_0",
     "dis",
     "disable",
     "disabled",
@@ -52,6 +53,7 @@ const USELESS_ZERO_NAMES: &[&str] = &[
     "passthru",
 ];
 const USELESS_ONE_NAMES: &[&str] = &[
+    "_1",
     "en",
     "enable",
     "enabled",


### PR DESCRIPTION
Typically a variant name of "0" gets transformed to "_0", and "1" to "_1". This will let the useless enums transform clear variants named "0" or "1" as desired.