### PR TITLE
Fix field deduplication

### DIFF
--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -285,6 +285,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
             fields: Vec::new(),
         };
 
+        let mut field_name_counts: BTreeMap<String, usize> = BTreeMap::new();
         for f in &proto.fields {
             if f.derived_from.is_some() {
                 warn!("unsupported derived_from in fieldset");
@@ -299,7 +300,13 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                 None
             };
 
-            let field_name = replace_suffix(&f.name, "");
+            let mut field_name = replace_suffix(&f.name, "");
+
+            let field_name_count = field_name_counts.entry(field_name.clone()).or_insert(0);
+            *field_name_count += 1;
+            if *field_name_count > 1 {
+                field_name = format!("{}{}", field_name, field_name_count);
+            }
 
             let mut field = Field {
                 name: field_name.clone(),

--- a/tests/rename_dups.rs
+++ b/tests/rename_dups.rs
@@ -1,0 +1,92 @@
+use chiptool::{ir::IR, svd2ir::convert_peripheral, transform::sanitize::Sanitize};
+use svd_parser::ValidateLevel;
+
+#[test]
+fn duplicate_svd_fields_should_not_collide() -> Result<(), Box<dyn std::error::Error>> {
+    let input_svd = r#"
+        <device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+            <name>duplicate_fields_should_not_collide</name>
+            <peripherals>
+                <peripheral>
+                    <name>PERIPHERAL</name>
+                    <baseAddress>0x0</baseAddress>
+                    <registers>
+                        <register>
+                            <name>Fieldset</name>
+                            <addressOffset>0x41F</addressOffset>
+                            <fields>
+                                <field>
+                                    <name>Reserved</name>
+                                    <lsb>1</lsb>
+                                    <msb>2</msb>
+                                </field>
+                                <field>
+                                    <name>Reserved</name>
+                                    <lsb>3</lsb>
+                                    <msb>4</msb>
+                                </field>
+                            </fields>
+                        </register>
+                    </registers>
+                </peripheral>
+            </peripherals>
+        </device> 
+    "#;
+
+    let config = svd_parser::Config::default()
+        .expand_properties(true)
+        .validate_level(ValidateLevel::Disabled);
+
+    let device = svd_parser::parse_with_config(input_svd, &config)?;
+    let mut ir = IR::new();
+    convert_peripheral(&mut ir, device.peripherals.iter().next().unwrap())?;
+
+    let (name, fieldset) = ir.fieldsets.iter().next().expect("Fieldset not found");
+
+    assert_eq!(name, "Fieldset");
+
+    let field_names = fieldset
+        .fields
+        .iter()
+        .map(|field| &field.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(field_names, &["Reserved", "Reserved2"]);
+
+    Ok(())
+}
+
+#[test]
+fn duplicate_ir_fields_should_not_collide() -> Result<(), Box<dyn std::error::Error>> {
+    let input_yaml = r#"
+    block/BLOCK:
+      items:
+        - name: register
+          byte_offset: 0
+          bit_size: 32
+          fieldset: regs::Fieldset
+    fieldset/regs::Fieldset:
+      fields:
+      - name: reserved
+        bit_offset: 0
+        bit_size: 1
+      - name: reserved
+        bit_offset: 1
+        bit_size: 1
+    "#;
+    let ir: IR = serde_yaml::from_slice(input_yaml.as_bytes())?;
+
+    let (name, fieldset) = ir.fieldsets.iter().next().expect("Fieldset not found");
+
+    assert_eq!(name, "regs::Fieldset");
+
+    let field_names = fieldset
+        .fields
+        .iter()
+        .map(|field| &field.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(field_names, &["reserved", "reserved2"]);
+
+    Ok(())
+}


### PR DESCRIPTION
#93 actually missed the part of the code where the field itself is named.  This PR ensures fields are renamed.

This is marked as a draft because I added a couple tests to define the expected behavior.  Beyond making sure that this is the right shape for tests to take, the `duplicate_ir_fields_should_not_collide` test fails.  Should deduplication happen when parsing SVD and YAML definitions or just SVDs?