### PR TITLE
Change a few panics into Result

### DIFF
--- a/src/commands/gen_block.rs
+++ b/src/commands/gen_block.rs
@@ -41,16 +41,14 @@ pub fn gen_block(args: GenBlock) -> Result<()> {
         }
     }
 
-    crate::transform::expand_extends::ExpandExtends {}
-        .run(&mut ir)
-        .unwrap();
+    crate::transform::expand_extends::ExpandExtends {}.run(&mut ir)?;
 
     // Ensure consistent sort order in the YAML.
-    crate::transform::sort::Sort {}.run(&mut ir).unwrap();
+    crate::transform::sort::Sort {}.run(&mut ir)?;
 
     let generate_opts = get_generate_opts(args.gen_shared)?;
 
-    let items = generate::render(&ir, &generate_opts).unwrap();
+    let items = generate::render(&ir, &generate_opts)?;
     fs::write(&args.output, items.to_string())?;
 
     Ok(())

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -2,7 +2,7 @@ use crate::commands::{
     apply_transform, clean_up_ir, get_generate_opts, load_svd, GenerateShared, NamespaceMode,
 };
 use crate::{generate, svd2ir};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use std::fs;
 use std::fs::File;
@@ -58,10 +58,16 @@ pub fn generate(args: Generate) -> Result<()> {
         std::env::current_dir()?
     };
 
-    let items = generate::render(&ir, &generate_opts).unwrap();
+    let items = generate::render(&ir, &generate_opts)?;
     fs::write(output.join("lib.rs"), items.to_string())?;
 
-    let device_x = generate::render_device_x(&ir, ir.devices.values().next().unwrap())?;
+    let device_x = generate::render_device_x(
+        &ir,
+        ir.devices
+            .values()
+            .next()
+            .ok_or_else(|| anyhow!("Expected at least one device to be defined"))?,
+    )?;
     fs::write(output.join("device.x"), device_x)?;
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,7 +80,7 @@ pub fn extract_peripheral(
     namespace_names(p, &mut ir, namespace_mode);
 
     // Ensure consistent sort order in the YAML.
-    crate::transform::sort::Sort {}.run(&mut ir).unwrap();
+    crate::transform::sort::Sort {}.run(&mut ir)?;
 
     Ok(ir)
 }

--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -23,7 +23,10 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
         match &i.inner {
             BlockItemInner::Register(r) => {
                 let reg_ty = if let Some(fieldset_path) = &r.fieldset {
-                    let _f = ir.fieldsets.get(fieldset_path).unwrap();
+                    let _f = ir
+                        .fieldsets
+                        .get(fieldset_path)
+                        .ok_or_else(|| anyhow!("Couldn't find fieldset: {fieldset_path}"))?;
                     util::relative_path(fieldset_path, path)
                 } else {
                     match r.bit_size {

--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -31,7 +31,7 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         16 => quote!(u16),
                         32 => quote!(u32),
                         64 => quote!(u64),
-                        _ => panic!("Invalid register bit size {}", r.bit_size),
+                        _ => bail!("Invalid register bit size {}", r.bit_size),
                     }
                 };
 

--- a/src/generate/enumm.rs
+++ b/src/generate/enumm.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -26,7 +26,7 @@ pub fn render(opts: &super::Options, _ir: &IR, e: &Enum, path: &str) -> Result<T
         9..=16 => quote!(u16),
         17..=32 => quote!(u32),
         33..=64 => quote!(u64),
-        _ => panic!("Invalid bit_size {}", e.bit_size),
+        _ => bail!("Invalid bit_size {}", e.bit_size),
     };
 
     let (_, name) = super::split_path(path);

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -35,9 +35,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
         let from_bits: TokenStream;
 
         if let Some(e_path) = &f.enumm {
-            let Some(e) = ir.enums.get(e_path) else {
-                bail!("missing enum {}", e_path);
-            };
+            let e = get_ref!(ir, enums, e_path)?;
 
             let enum_ty = match e.bit_size {
                 1..=8 => quote!(u8),

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -20,7 +20,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
         9..=16 => quote!(u16),
         17..=32 => quote!(u32),
         33..=64 => quote!(u64),
-        _ => panic!("Invalid bit_size {}", fs.bit_size),
+        _ => bail!("Invalid bit_size {}", fs.bit_size),
     };
 
     for f in sorted(&fs.fields, |f| (f.bit_offset.clone(), f.name.clone())) {
@@ -36,7 +36,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
 
         if let Some(e_path) = &f.enumm {
             let Some(e) = ir.enums.get(e_path) else {
-                panic!("missing enum {}", e_path);
+                bail!("missing enum {}", e_path);
             };
 
             let enum_ty = match e.bit_size {
@@ -44,7 +44,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                 9..=16 => quote!(u16),
                 17..=32 => quote!(u32),
                 33..=64 => quote!(u64),
-                _ => panic!("Invalid bit_size {}", e.bit_size),
+                _ => bail!("Invalid bit_size {}", e.bit_size),
             };
 
             field_ty = util::relative_path(e_path, path);
@@ -57,7 +57,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                 9..=16 => quote!(u16),
                 17..=32 => quote!(u32),
                 33..=64 => quote!(u64),
-                _ => panic!("Invalid bit_size {}", f.bit_size),
+                _ => bail!("Invalid bit_size {}", f.bit_size),
             };
             to_bits = quote!(val as #ty);
             from_bits = if f.bit_size == 1 {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use de::MapAccess;
 use serde::{de, de::Visitor, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::BTreeMap;
@@ -23,6 +24,22 @@ impl IR {
         self.fieldsets.extend(other.fieldsets);
         self.enums.extend(other.enums);
     }
+}
+
+macro_rules! get_ref {
+    ($ir:expr, $type:ident, $name:expr) => {
+        $ir.$type.get($name).ok_or_else(|| {
+            anyhow::anyhow!("Failed to find element {} in {}", $name, stringify!($type))
+        })
+    };
+}
+
+macro_rules! get_mut {
+    ($ir:expr, $type:ident, $name:expr) => {
+        $ir.$type.get_mut($name).ok_or_else(|| {
+            anyhow::anyhow!("Failed to find element {} in {}", $name, stringify!($type))
+        })
+    };
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+#[macro_use]
+pub mod ir;
+
 pub mod commands;
 pub mod generate;
-pub mod ir;
 pub mod svd2ir;
 pub mod transform;
 pub mod util;

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, bail};
 use clap::ValueEnum;
 use log::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -127,9 +127,9 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
                             (Some(r), Some(w), None) => Some(EnumSet::ReadWrite(r, w)),
                             (Some(r), None, Some(w)) => Some(EnumSet::ReadWrite(r, w)),
                             (None, Some(w), Some(r)) => Some(EnumSet::ReadWrite(r, w)),
-                            (Some(_), Some(_), Some(_)) => panic!(
-                                "cannot have enumeratedvalues for read, write and readwrite!"
-                            ),
+                            (Some(_), Some(_), Some(_)) => {
+                                bail!("cannot have enumeratedvalues for read, write and readwrite!")
+                            }
                         };
 
                         if let Some(set) = set {

--- a/src/transform/add_enum_variants.rs
+++ b/src/transform/add_enum_variants.rs
@@ -13,7 +13,7 @@ pub struct AddEnumVariants {
 impl AddEnumVariants {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.enums.keys().cloned(), &self.enumm) {
-            let d = ir.enums.get_mut(&id).unwrap();
+            let d = get_mut!(ir, enums, &id)?;
             d.variants.extend(self.variants.clone());
         }
 

--- a/src/transform/add_fields.rs
+++ b/src/transform/add_fields.rs
@@ -12,7 +12,7 @@ pub struct AddFields {
 impl AddFields {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
-            let d = ir.fieldsets.get_mut(&id).unwrap();
+            let d = get_mut!(ir, fieldsets, &id)?;
             d.fields.extend(self.fields.clone());
         }
 

--- a/src/transform/add_interrupts.rs
+++ b/src/transform/add_interrupts.rs
@@ -12,7 +12,7 @@ pub struct AddInterrupts {
 impl AddInterrupts {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.devices.keys().cloned(), &self.devices) {
-            let d = ir.devices.get_mut(&id).unwrap();
+            let d = get_mut!(ir, devices, &id)?;
             d.interrupts.extend(self.interrupts.clone());
         }
         Ok(())

--- a/src/transform/add_peripherals.rs
+++ b/src/transform/add_peripherals.rs
@@ -12,7 +12,7 @@ pub struct AddPeripherals {
 impl AddPeripherals {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.devices.keys().cloned(), &self.devices) {
-            let d = ir.devices.get_mut(&id).unwrap();
+            let d = get_mut!(ir, devices, &id)?;
             d.peripherals.extend(self.peripherals.clone());
         }
         Ok(())

--- a/src/transform/add_registers.rs
+++ b/src/transform/add_registers.rs
@@ -12,7 +12,7 @@ pub struct AddRegisters {
 impl AddRegisters {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.blocks.keys().cloned(), &self.block) {
-            let d = ir.blocks.get_mut(&id).unwrap();
+            let d = get_mut!(ir, blocks, &id)?;
             d.items.extend(self.registers.clone());
         }
 

--- a/src/transform/delete_enum_variants.rs
+++ b/src/transform/delete_enum_variants.rs
@@ -14,7 +14,7 @@ pub struct DeleteEnumVariants {
 impl DeleteEnumVariants {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.enums.keys().cloned(), &self.enumm) {
-            let e = ir.enums.get_mut(&id).unwrap();
+            let e = get_mut!(ir, enums, &id)?;
 
             e.variants.retain(|variant| {
                 if self.from.is_match(&variant.name) {

--- a/src/transform/delete_fields.rs
+++ b/src/transform/delete_fields.rs
@@ -12,7 +12,7 @@ pub struct DeleteFields {
 impl DeleteFields {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
-            let fs = ir.fieldsets.get_mut(&id).unwrap();
+            let fs = get_mut!(ir, fieldsets, &id)?;
             fs.fields.retain(|f| !self.from.is_match(&f.name));
         }
         Ok(())

--- a/src/transform/delete_peripherals.rs
+++ b/src/transform/delete_peripherals.rs
@@ -13,7 +13,7 @@ pub struct DeletePeripherals {
 impl DeletePeripherals {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.devices.keys().cloned(), &self.devices) {
-            let d = ir.devices.get_mut(&id).unwrap();
+            let d = get_mut!(ir, devices, &id)?;
             d.peripherals.retain(|i| {
                 info!("deleting peripheral {}", &i.name);
                 !self.from.is_match(&i.name)

--- a/src/transform/delete_registers.rs
+++ b/src/transform/delete_registers.rs
@@ -12,7 +12,7 @@ pub struct DeleteRegisters {
 impl DeleteRegisters {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.blocks.keys().cloned(), &self.block) {
-            let b = ir.blocks.get_mut(&id).unwrap();
+            let b = get_mut!(ir, blocks, &id)?;
             b.items.retain(|i| !self.from.is_match(&i.name));
         }
         Ok(())

--- a/src/transform/expand_extends.rs
+++ b/src/transform/expand_extends.rs
@@ -17,12 +17,12 @@ impl ExpandExtends {
             .map(|(k, v)| (k.clone(), v.extends.clone()))
             .collect();
         for name in topological_sort(deps)? {
-            let block = ir.blocks.get(&name).unwrap();
+            let block = get_ref!(ir, blocks, &name)?;
             if let Some(parent_name) = &block.extends {
-                let parent = ir.blocks.get(parent_name).unwrap();
+                let parent = get_ref!(ir, blocks, parent_name)?;
 
                 let items = parent.items.clone();
-                let block = ir.blocks.get_mut(&name).unwrap();
+                let block = get_mut!(ir, blocks, &name)?;
 
                 for i in items {
                     if !block.items.iter().any(|j| j.name == i.name) {
@@ -38,12 +38,12 @@ impl ExpandExtends {
             .map(|(k, v)| (k.clone(), v.extends.clone()))
             .collect();
         for name in topological_sort(deps)? {
-            let fieldset = ir.fieldsets.get(&name).unwrap();
+            let fieldset = get_ref!(ir, fieldsets, &name)?;
             if let Some(parent_name) = &fieldset.extends {
-                let parent = ir.fieldsets.get(parent_name).unwrap();
+                let parent = get_ref!(ir, fieldsets, parent_name)?;
 
                 let items = parent.fields.clone();
-                let fieldset = ir.fieldsets.get_mut(&name).unwrap();
+                let fieldset = get_mut!(ir, fieldsets, &name)?;
 
                 for i in items {
                     if !fieldset.fields.iter().any(|j| j.name == i.name) {

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -48,7 +48,7 @@ impl FixRegisterBitSizes {
                             }
                             Some(fs) => {
                                 // expand the size of the existing fieldset.
-                                let fs = ir.fieldsets.get_mut(fs).unwrap();
+                                let fs = get_mut!(ir, fieldsets, fs)?;
                                 fs.bit_size = good_bit_size;
                             }
                         }

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
 use crate::ir::*;
@@ -18,7 +19,7 @@ impl FixRegisterBitSizes {
                         9..=16 => 16,
                         17..=32 => 32,
                         33..=64 => 64,
-                        65.. => panic!("Invalid register bit size {}", r.bit_size),
+                        65.. => bail!("Invalid register bit size {}", r.bit_size),
                     };
                     if r.bit_size != good_bit_size {
                         r.bit_size = good_bit_size;
@@ -41,7 +42,7 @@ impl FixRegisterBitSizes {
                                         extends: None,
                                     };
                                     if ir.fieldsets.insert(i.name.clone(), fs).is_some() {
-                                        panic!("dup fieldset {}", i.name);
+                                        bail!("dup fieldset {}", i.name);
                                     }
                                 }
                             }

--- a/src/transform/make_block.rs
+++ b/src/transform/make_block.rs
@@ -18,14 +18,14 @@ pub struct MakeBlock {
 impl MakeBlock {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.blocks.keys().cloned(), &self.blocks) {
-            let b = ir.blocks.get_mut(&id).unwrap();
+            let b = get_mut!(ir, blocks, &id)?;
             let groups = match_groups(
                 b.items.iter().map(|f| f.name.clone()),
                 &self.from,
                 &self.to_outer,
             );
             for (to, group) in groups {
-                let b = ir.blocks.get_mut(&id).unwrap();
+                let b = get_mut!(ir, blocks, &id)?;
                 info!("blockifizing to {}", to);
 
                 // Grab all items into a vec
@@ -68,7 +68,7 @@ impl MakeBlock {
                 ir.blocks.insert(dest.clone(), b2);
 
                 // Remove all items
-                let b = ir.blocks.get_mut(&id).unwrap();
+                let b = get_mut!(ir, blocks, &id)?;
                 b.items.retain(|i| !group.contains(&i.name));
 
                 // Create the new block item

--- a/src/transform/make_field_array.rs
+++ b/src/transform/make_field_array.rs
@@ -17,7 +17,7 @@ pub struct MakeFieldArray {
 impl MakeFieldArray {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldsets) {
-            let b = ir.fieldsets.get_mut(&id).unwrap();
+            let b = get_mut!(ir, fieldsets, &id)?;
             let groups = match_groups(
                 b.fields.iter().map(|f| f.name.clone()),
                 &self.from,

--- a/src/transform/make_register_array.rs
+++ b/src/transform/make_register_array.rs
@@ -25,7 +25,7 @@ fn layout() -> CheckLevel {
 impl MakeRegisterArray {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.blocks.keys().cloned(), &self.blocks) {
-            let b = ir.blocks.get_mut(&id).unwrap();
+            let b = get_mut!(ir, blocks, &id)?;
             let groups = match_groups(b.items.iter().map(|f| f.name.clone()), &self.from, &self.to);
             for (to, group) in groups {
                 info!("arrayizing to {}", to);

--- a/src/transform/modify_byte_offset.rs
+++ b/src/transform/modify_byte_offset.rs
@@ -19,7 +19,7 @@ impl ModifyByteOffset {
         let mut err_names = Vec::new();
 
         for id in match_all(ir.blocks.keys().cloned(), &self.blocks) {
-            let b = ir.blocks.get_mut(&id).unwrap();
+            let b = get_mut!(ir, blocks, &id)?;
             for i in &mut b.items {
                 if let Some(exclude) = &self.exclude_items {
                     if exclude.is_match(&i.name) {

--- a/src/transform/modify_byte_offset.rs
+++ b/src/transform/modify_byte_offset.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
 use super::common::*;
@@ -44,7 +45,7 @@ impl ModifyByteOffset {
                 ));
             }
 
-            panic!("{err_msg}")
+            bail!("{err_msg}")
         }
 
         Ok(())

--- a/src/transform/modify_fields_enum.rs
+++ b/src/transform/modify_fields_enum.rs
@@ -30,7 +30,7 @@ impl ModifyFieldsEnum {
                 }
             };
 
-            let fs = ir.fieldsets.get_mut(&id).unwrap();
+            let fs = get_mut!(ir, fieldsets, &id)?;
             fs.fields
                 .iter_mut()
                 .filter(|f| self.field.is_match(&f.name))

--- a/src/transform/modify_registers.rs
+++ b/src/transform/modify_registers.rs
@@ -13,7 +13,7 @@ pub struct ModifyRegisters {
 impl ModifyRegisters {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.blocks.keys().cloned(), &self.blocks) {
-            let block = ir.blocks.get_mut(&id).unwrap();
+            let block = get_mut!(ir, blocks, &id)?;
 
             for item in block
                 .items

--- a/src/transform/rename_enum_variants.rs
+++ b/src/transform/rename_enum_variants.rs
@@ -14,7 +14,7 @@ pub struct RenameEnumVariants {
 impl RenameEnumVariants {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.enums.keys().cloned(), &self.enumm) {
-            let e = ir.enums.get_mut(&id).unwrap();
+            let e = get_mut!(ir, enums, &id)?;
             for i in &mut e.variants {
                 if let Some(name) = match_expand(&i.name, &self.from, &self.to) {
                     i.name = name;

--- a/src/transform/rename_fields.rs
+++ b/src/transform/rename_fields.rs
@@ -20,7 +20,7 @@ impl RenameFields {
         let mut had_duplicate = false;
 
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
-            let fs = ir.fieldsets.get_mut(&id).unwrap();
+            let fs = get_mut!(ir, fieldsets, &id)?;
             let renames = renames.entry(id.clone()).or_default();
 
             let fmt = |field| format!("field {field} in fieldset {id}");

--- a/src/transform/rename_registers.rs
+++ b/src/transform/rename_registers.rs
@@ -20,7 +20,7 @@ impl RenameRegisters {
         let mut had_duplicate = false;
 
         for id in match_all(ir.blocks.keys().cloned(), &self.block) {
-            let b = ir.blocks.get_mut(&id).unwrap();
+            let b = get_mut!(ir, blocks, &id)?;
             let renames = renames.entry(id.clone()).or_default();
 
             let fmt = |field| format!("register {field} in block {id}");

--- a/src/transform/resize_enums.rs
+++ b/src/transform/resize_enums.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
 
 use crate::ir::*;
@@ -17,7 +17,7 @@ impl ResizeEnums {
         let ids = match_all(ir.enums.keys().cloned(), &self.emumm);
 
         if self.bit_size == 0 {
-            panic!("Cannot resize an enum to 0 bits (delete the enum?)");
+            bail!("Cannot resize an enum to 0 bits (delete the enum?)");
         }
 
         // Resize the enums
@@ -61,7 +61,7 @@ fn verify_variants(ir: &IR, enumm: &str) -> anyhow::Result<()> {
     }
 
     if error {
-        panic!();
+        bail!("Failed to verify variant {enumm}");
     }
 
     Ok(())
@@ -112,7 +112,7 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
         }
 
         if error {
-            panic!();
+            bail!("Fields overlap in {enumm}");
         }
     }
 

--- a/src/transform/resize_enums.rs
+++ b/src/transform/resize_enums.rs
@@ -24,7 +24,7 @@ impl ResizeEnums {
         for enumm in ids.iter() {
             log::info!("Resizing enum {} to {} bits", enumm, self.bit_size);
 
-            let enumm = ir.enums.get_mut(enumm).unwrap();
+            let enumm = get_mut!(ir, enums, enumm)?;
             enumm.bit_size = self.bit_size;
         }
 
@@ -39,7 +39,7 @@ impl ResizeEnums {
 
 /// Verify all enum variants fit within the bit size of the enum after resize.
 fn verify_variants(ir: &IR, enumm: &str) -> anyhow::Result<()> {
-    let e = ir.enums.get(enumm).unwrap();
+    let e = get_ref!(ir, enums, enumm)?;
     let max_value = 2_u64
         .checked_pow(e.bit_size)
         .context("Bit size is too large")?


### PR DESCRIPTION
When an error occurs, a direct panic misses the opportunity to provide additional `.context`. Especially when using as a library, a panic can be harder to deal with.

This PR removes a few of the many panics in the codebase in favor of anyhow errors. Mostly supersedes #107.

Added macro rules for getting refs/muts from the IR subtree. This was the easiest non-invasive way to generate nice'ish errors for this common operation. Accessors on IR are not viable due to lifetimes between the subtrees. I considered moving from BTreeMap for these subtrees to something like IRTree that returns Result instead of Option on `get` and `get_mut`, but that is a bigger change.