### PR TITLE
Add MapEnumVariants transform and supporting test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.org
 *.rs.bk
 target
+.DS_Store

--- a/src/transform/map_enum_variants.rs
+++ b/src/transform/map_enum_variants.rs
@@ -1,0 +1,38 @@
+//! Simple transform for enum variant names
+//!
+//! This is useful when an SVD contains enum variants with purely numeric identifiers.
+//! It is not meant to be used to apply inflection, that's what the `Sanitize` transform is for.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MapEnumVariants {
+    #[serde(rename = "enum")]
+    pub enumm: RegexSet,
+    #[serde(default)]
+    pub variants: BTreeMap<String, String>,
+    #[serde(default)]
+    pub descriptions: BTreeMap<String, String>,
+}
+
+impl MapEnumVariants {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        for id in match_all(ir.enums.keys().cloned(), &self.enumm) {
+            let e = ir.enums.get_mut(&id).unwrap();
+            for variant in e.variants.iter_mut() {
+                if let Some(new_description) = self.descriptions.get(&variant.name) {
+                    variant.description = Some(new_description.clone());
+                }
+                if let Some(new_name) = self.variants.get(&variant.name) {
+                    variant.name = new_name.clone();
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -271,4 +271,5 @@ transforms!(
     rename_interrupts::RenameInterrupts,
     rename_peripherals::RenamePeripherals,
     clean_descriptions::CleanDescriptions,
+    map_enum_variants::MapEnumVariants,
 );

--- a/tests/map_enum_variants.rs
+++ b/tests/map_enum_variants.rs
@@ -1,0 +1,51 @@
+use chiptool::{ir::IR, transform::map_enum_variants::MapEnumVariants};
+
+#[test]
+fn duplicate_ir_enums_should_be_updated() -> Result<(), Box<dyn std::error::Error>> {
+    let input_yaml = r#"
+    block/BLOCK:
+      items:
+        - name: register
+          byte_offset: 0
+          bit_size: 32
+          fieldset: regs::Fieldset
+    fieldset/regs::Fieldset:
+      fields:
+      - name: reserved
+        bit_offset: 0
+        bit_size: 3
+        enum: vals::Enumm
+    enum/vals::Enumm:
+      bit_size: 3
+      variants:
+        - { name: VariantOne, value: 0b001 }
+        - { name: VariantTwo, value: 0b010 }
+        - { name: VariantThree, value: 0b011 }
+    "#;
+
+    let transform_yaml = r#"
+      !MapEnumVariants
+      enum: vals::Enumm
+      variants:
+        VariantOne: _1
+        VariantTwo: _2
+        VariantThree: _3
+    "#;
+
+    let mut ir: IR = serde_yaml::from_slice(input_yaml.as_bytes())?;
+
+    let transform = serde_yaml::from_slice::<MapEnumVariants>(transform_yaml.as_bytes())?;
+    transform.run(&mut ir)?;
+
+    let enumm = ir.enums.get("vals::Enumm").expect("Enum not found");
+
+    let variant_names = enumm
+        .variants
+        .iter()
+        .map(|field| &field.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(variant_names, &["_1", "_2", "_3"]);
+
+    Ok(())
+}


### PR DESCRIPTION
This is useful when an SVD contains enum variants with purely numeric identifiers as Renesas is prone to doing.

It should/could potentially be extended to use regular expressions and merged with the existing `RenameEnumVariants` transform. However this is useful in cases where something akin to a `RegexSet` might be used, where `RenameEnumVariants` is more useful where a small number of variants need to be changed.

This could potentially be merged with `AddEnumVariants` but the current behavior is to simply ignore variants that don't match.  That allows a single transform to be applied to slightly different variations of an enum.

This could potentially be merged with the `RenameFields` or more general `Rename` transform.