### PR TITLE
Enforce `FieldSet` order

### DIFF
--- a/src/commands/extract_all.rs
+++ b/src/commands/extract_all.rs
@@ -177,8 +177,8 @@ fn extract_relevant(block_name: &str, ir: &IR) -> Result<IR> {
             state.fieldsets.schedule(extends)?;
         }
 
-        for item in fieldset.fields.iter() {
-            if let Some(enumm) = &item.enumm {
+        for item in fieldset.fields() {
+            if let Some(enumm) = item.enumm() {
                 state.enums.schedule(enumm)?;
             }
         }

--- a/src/commands/fmt.rs
+++ b/src/commands/fmt.rs
@@ -27,8 +27,8 @@ pub fn fmt(args: Fmt) -> Result<()> {
         if args.remove_unused {
             let mut used_enums = BTreeSet::new();
             for fs in ir.fieldsets.values_mut() {
-                for f in fs.fields.iter_mut().filter(|f| f.enumm.is_some()) {
-                    used_enums.insert(f.enumm.as_ref().unwrap().clone());
+                for enumm in fs.fields().filter_map(|f| f.enumm()) {
+                    used_enums.insert(enumm.clone());
                 }
             }
 
@@ -55,8 +55,8 @@ pub fn fmt(args: Fmt) -> Result<()> {
 
         for b in ir.fieldsets.values_mut() {
             cleanup(&mut b.description);
-            for i in b.fields.iter_mut() {
-                cleanup(&mut i.description);
+            for i in b.fields_mut() {
+                cleanup(i.description_opt_mut());
             }
         }
 

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -6,14 +6,14 @@ use quote::quote;
 use crate::ir::*;
 use crate::util;
 
-use super::{sorted, with_defmt_cfg};
+use super::with_defmt_cfg;
 
 pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Result<TokenStream> {
     let span = Span::call_site();
     let mut items = TokenStream::new();
-    let mut field_names = Vec::with_capacity(fs.fields.len());
-    let mut field_getters = Vec::with_capacity(fs.fields.len());
-    let mut field_types = Vec::with_capacity(fs.fields.len());
+    let mut field_names = Vec::with_capacity(fs.fields().len());
+    let mut field_getters = Vec::with_capacity(fs.fields().len());
+    let mut field_types = Vec::with_capacity(fs.fields().len());
 
     let ty = match fs.bit_size {
         1..=8 => quote!(u8),
@@ -23,18 +23,18 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
         _ => bail!("Invalid bit_size {}", fs.bit_size),
     };
 
-    for f in sorted(&fs.fields, |f| (f.bit_offset.clone(), f.name.clone())) {
-        let name = Ident::new(&f.name, span);
-        let name_set = Ident::new(&format!("set_{}", f.name), span);
-        let off_in_reg = f.bit_offset.clone();
-        let _bit_size = f.bit_size as usize;
-        let mask = util::hex(1u64.wrapping_shl(f.bit_size).wrapping_sub(1));
-        let doc = util::doc(&f.description);
+    for f in fs.fields() {
+        let name = Ident::new(f.name(), span);
+        let name_set = Ident::new(&format!("set_{}", f.name()), span);
+        let off_in_reg = f.bit_offset().clone();
+        let _bit_size = f.bit_size() as usize;
+        let mask = util::hex(1u64.wrapping_shl(f.bit_size()).wrapping_sub(1));
+        let doc = util::doc(f.description());
         let field_ty: TokenStream;
         let to_bits: TokenStream;
         let from_bits: TokenStream;
 
-        if let Some(e_path) = &f.enumm {
+        if let Some(e_path) = f.enumm() {
             let e = get_ref!(ir, enums, e_path)?;
 
             let enum_ty = match e.bit_size {
@@ -49,32 +49,32 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
             to_bits = quote!(val.to_bits() as #ty);
             from_bits = quote!(#field_ty::from_bits(val as #enum_ty));
         } else {
-            field_ty = match f.bit_size {
+            field_ty = match f.bit_size() {
                 1 => quote!(bool),
                 2..=8 => quote!(u8),
                 9..=16 => quote!(u16),
                 17..=32 => quote!(u32),
                 33..=64 => quote!(u64),
-                _ => bail!("Invalid bit_size {}", f.bit_size),
+                _ => bail!("Invalid bit_size {}", f.bit_size()),
             };
             to_bits = quote!(val as #ty);
-            from_bits = if f.bit_size == 1 {
+            from_bits = if f.bit_size() == 1 {
                 quote!(val != 0)
             } else {
                 quote!(val as #field_ty)
             }
         }
 
-        if let Some(array) = &f.array {
+        if let Some(array) = f.array() {
             // Print array fields using array indexing: "field[0]"
             for i in 0..array.len() {
-                let debug_name = format!("{}[{i}]", f.name);
+                let debug_name = format!("{}[{i}]", f.name());
                 field_names.push(debug_name);
                 field_types.push(field_ty.clone());
                 field_getters.push(quote!(self.#name(#i)));
             }
         } else {
-            field_names.push(f.name.clone());
+            field_names.push(f.name().clone());
             field_types.push(field_ty.clone());
             field_getters.push(quote!(self.#name()));
         }
@@ -82,7 +82,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
         match off_in_reg {
             BitOffset::Regular(off_in_reg) => {
                 let off_in_reg = off_in_reg as usize;
-                if let Some(array) = &f.array {
+                if let Some(array) = f.array() {
                     let (len, offs_expr) = super::process_array(array);
                     items.extend(quote!(
                         #doc
@@ -141,7 +141,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                     }
                 }
 
-                if let Some(array) = &f.array {
+                if let Some(array) = f.array() {
                     let (len, offs_expr) = super::process_array(array);
                     items.extend(quote!(
                         #doc

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,3 +1,6 @@
+mod fieldset;
+pub use fieldset::{FieldSet, UnorderedFieldSet};
+
 use anyhow::Result;
 use de::MapAccess;
 use serde::{de, de::Visitor, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
@@ -161,18 +164,6 @@ pub enum Access {
     ReadWrite,
     Read,
     Write,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct FieldSet {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub extends: Option<String>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    #[serde(default = "default_32", skip_serializing_if = "is_32")]
-    pub bit_size: u32,
-    pub fields: Vec<Field>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq)]

--- a/src/ir/fieldset.rs
+++ b/src/ir/fieldset.rs
@@ -1,0 +1,215 @@
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+fn sort_fn(a: &Field, b: &Field) -> std::cmp::Ordering {
+    a.bit_offset.cmp(&b.bit_offset).then(a.name.cmp(&b.name))
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UnorderedFieldSet {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default = "default_32", skip_serializing_if = "is_32")]
+    pub bit_size: u32,
+
+    pub fields: Vec<Field>,
+}
+
+impl From<UnorderedFieldSet> for FieldSet {
+    fn from(mut value: UnorderedFieldSet) -> Self {
+        value.fields.sort_by(sort_fn);
+        let fields = value.fields.into_iter().map(FieldView).collect();
+
+        Self {
+            extends: value.extends,
+            description: value.description,
+            bit_size: value.bit_size,
+            fields,
+        }
+    }
+}
+
+impl From<FieldSet> for UnorderedFieldSet {
+    fn from(value: FieldSet) -> Self {
+        Self {
+            extends: value.extends,
+            description: value.description,
+            bit_size: value.bit_size,
+            fields: value.fields.into_iter().map(|v| v.0).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(from = "UnorderedFieldSet", into = "UnorderedFieldSet")]
+pub struct FieldSet {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default = "default_32", skip_serializing_if = "is_32")]
+    pub bit_size: u32,
+
+    /// The fields in this field set, always ordered according
+    /// to `sort_fn`
+    fields: Vec<FieldView>,
+}
+
+impl FieldSet {
+    pub fn take_fields(&mut self) -> Vec<Field> {
+        let fields = std::mem::take(&mut self.fields);
+        fields.into_iter().map(Into::into).collect()
+    }
+
+    /// Iterate over the fields of this fieldset.
+    ///
+    /// They are ordered by offset and name.
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = &FieldView> + Clone {
+        self.fields.iter()
+    }
+
+    /// Mutably iterate over the fields of this fieldset.
+    ///
+    /// They are ordered by offset and name.
+    pub fn fields_mut(&mut self) -> impl ExactSizeIterator<Item = &mut FieldView> {
+        self.fields.iter_mut()
+    }
+
+    pub fn retain_fields<F>(&mut self, f: F)
+    where
+        F: FnMut(&FieldView) -> bool,
+    {
+        self.fields.retain(f);
+    }
+
+    pub fn push(&mut self, field: Field) {
+        let index = self.fields.iter().enumerate().find_map(|(idx, f)| {
+            if sort_fn(f.as_ref(), &field).is_gt() {
+                Some(idx)
+            } else {
+                None
+            }
+        });
+
+        if let Some(index) = index {
+            self.fields.insert(index, field.into())
+        } else {
+            self.fields.push(field.into());
+        }
+    }
+
+    pub fn extend(&mut self, mut fields: Vec<Field>) {
+        // Sort provided list
+        fields.sort_by(sort_fn);
+
+        let mut result = Vec::with_capacity(self.fields.len() + fields.len());
+
+        // Merge-sort
+        let mut existing_fields = std::mem::take(&mut self.fields).into_iter();
+        let mut new_fields = fields.into_iter().map(FieldView::from);
+
+        let mut existing = None;
+        let mut new = None;
+        loop {
+            existing = existing.or_else(|| existing_fields.next());
+            new = new.or_else(|| new_fields.next());
+
+            let (new_e, new_n) = match (existing, new) {
+                (None, None) => break,
+                (None, Some(v)) | (Some(v), None) => {
+                    result.push(v);
+                    (None, None)
+                }
+                (Some(a), Some(b)) => match sort_fn(a.as_ref(), b.as_ref()) {
+                    std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+                        result.push(a);
+                        (None, Some(b))
+                    }
+                    std::cmp::Ordering::Greater => {
+                        result.push(b);
+                        (Some(a), None)
+                    }
+                },
+            };
+
+            existing = new_e;
+            new = new_n;
+        }
+
+        self.fields = result;
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldView(Field);
+
+impl From<Field> for FieldView {
+    fn from(value: Field) -> Self {
+        Self(value)
+    }
+}
+
+impl From<FieldView> for Field {
+    fn from(value: FieldView) -> Self {
+        value.0
+    }
+}
+
+impl FieldView {
+    // Bit offset is immutable for ordering purposes
+    pub fn bit_offset(&self) -> &BitOffset {
+        &self.0.bit_offset
+    }
+
+    // Name is immutable for ordering purposes
+    pub fn name(&self) -> &String {
+        &self.0.name
+    }
+
+    pub fn description(&self) -> Option<&String> {
+        self.0.description.as_ref()
+    }
+
+    pub fn description_opt_mut(&mut self) -> &mut Option<String> {
+        &mut self.0.description
+    }
+
+    pub fn set_description(&mut self, description: Option<String>) {
+        self.0.description = description;
+    }
+
+    pub fn bit_size(&self) -> u32 {
+        self.0.bit_size
+    }
+
+    pub fn set_bit_size(&mut self, bit_size: u32) {
+        self.0.bit_size = bit_size;
+    }
+
+    pub fn array(&self) -> Option<&Array> {
+        self.0.array.as_ref()
+    }
+
+    pub fn enumm(&self) -> Option<&String> {
+        self.0.enumm.as_ref()
+    }
+
+    pub fn enumm_opt_mut(&mut self) -> &mut Option<String> {
+        &mut self.0.enumm
+    }
+
+    pub fn set_enumm(&mut self, enumm: Option<String>) {
+        self.0.enumm = enumm;
+    }
+}
+
+impl AsRef<Field> for FieldView {
+    fn as_ref(&self) -> &Field {
+        &self.0
+    }
+}

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 use clap::ValueEnum;
 use log::*;
 use std::collections::{BTreeMap, BTreeSet};
@@ -278,7 +278,7 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
 
     // Convert fieldsets
     for proto in &fieldsets {
-        let mut fieldset = FieldSet {
+        let mut fieldset = UnorderedFieldSet {
             extends: None,
             description: proto.description.clone(),
             bit_size: proto.bit_size,
@@ -324,7 +324,10 @@ pub fn convert_peripheral(ir: &mut IR, p: &svd::Peripheral) -> anyhow::Result<()
         }
 
         let fieldset_name = fieldset_names.get(&proto.name).unwrap().clone();
-        assert!(ir.fieldsets.insert(fieldset_name, fieldset).is_none())
+        assert!(ir
+            .fieldsets
+            .insert(fieldset_name, fieldset.into())
+            .is_none())
     }
 
     for proto in &enums {

--- a/src/transform/add_fields.rs
+++ b/src/transform/add_fields.rs
@@ -13,7 +13,7 @@ impl AddFields {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
             let d = get_mut!(ir, fieldsets, &id)?;
-            d.fields.extend(self.fields.clone());
+            d.extend(self.fields.clone());
         }
 
         Ok(())

--- a/src/transform/common.rs
+++ b/src/transform/common.rs
@@ -154,10 +154,10 @@ pub(crate) fn match_expand(s: &str, regex: &RegexSet, res: &str) -> Option<Strin
 
 pub(crate) fn replace_enum_ids(ir: &mut IR, from: &BTreeSet<String>, to: String) {
     for (_, fs) in ir.fieldsets.iter_mut() {
-        for f in fs.fields.iter_mut() {
-            if let Some(id) = &mut f.enumm {
+        for f in fs.fields_mut() {
+            if let Some(id) = f.enumm() {
                 if from.contains(id) {
-                    *id = to.clone()
+                    f.set_enumm(Some(to.clone()));
                 }
             }
         }
@@ -293,19 +293,19 @@ pub(crate) fn append_variant_desc_to_field(
 ) {
     for fs in ir.fieldsets.values_mut() {
         for f in fs
-            .fields
-            .iter_mut()
-            .filter(|f| bit_size.is_none_or(|s| s == f.bit_size) && f.enumm.is_some())
+            .fields_mut()
+            .filter(|f| bit_size.is_none_or(|s| s == f.bit_size()) && f.enumm().is_some())
         {
+            let enumm = f.enumm().cloned().unwrap();
             for (_, desc_string) in enum_desc_pair
                 .iter()
-                .filter(|(e_name, _)| **e_name == f.enumm.clone().unwrap())
+                .filter(|(e_name, _)| *e_name == &enumm)
             {
-                match &f.description {
+                match f.description() {
                     Some(desc) => {
-                        f.description = Some(format!("{}\n{}", desc.clone(), desc_string.clone()))
+                        f.set_description(Some(format!("{}\n{}", desc, desc_string)));
                     }
-                    None => f.description = Some(desc_string.clone()),
+                    None => f.set_description(Some(desc_string.clone())),
                 }
             }
         }

--- a/src/transform/delete_enums.rs
+++ b/src/transform/delete_enums.rs
@@ -44,10 +44,10 @@ impl DeleteEnums {
 
 pub(crate) fn remove_enum_ids(ir: &mut IR, from: &BTreeSet<String>) {
     for (_, fs) in ir.fieldsets.iter_mut() {
-        for f in fs.fields.iter_mut() {
-            if let Some(id) = &mut f.enumm {
+        for f in fs.fields_mut() {
+            if let Some(id) = f.enumm() {
                 if from.contains(id) {
-                    f.enumm = None
+                    f.set_enumm(None);
                 }
             }
         }

--- a/src/transform/delete_enums_used_in.rs
+++ b/src/transform/delete_enums_used_in.rs
@@ -20,8 +20,8 @@ impl DeleteEnumsUsedIn {
         for (id, fs) in ir.fieldsets.iter() {
             if self.fieldsets.is_match(id) {
                 info!("matched fieldset {}", id);
-                for f in &fs.fields {
-                    if let Some(id) = &f.enumm {
+                for f in fs.fields() {
+                    if let Some(id) = f.enumm() {
                         info!("deleting enum {}", id);
                         ids.insert(id.clone());
                     }

--- a/src/transform/delete_fields.rs
+++ b/src/transform/delete_fields.rs
@@ -13,7 +13,7 @@ impl DeleteFields {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldset) {
             let fs = get_mut!(ir, fieldsets, &id)?;
-            fs.fields.retain(|f| !self.from.is_match(&f.name));
+            fs.retain_fields(|f| !self.from.is_match(f.name()));
         }
         Ok(())
     }

--- a/src/transform/delete_fieldsets.rs
+++ b/src/transform/delete_fieldsets.rs
@@ -40,10 +40,16 @@ impl DeleteFieldsets {
 // 1. it has no Fields, or
 // 2. it has one Fields, which occupied entire Fieldset, and without a enum
 fn is_useless(fs: &FieldSet) -> bool {
-    match &fs.fields[..] {
-        [] => true,
-        [f] => fs.bit_size == f.bit_size && f.bit_offset.min_offset() == 0 && f.enumm.is_none(),
-        _ => false,
+    let mut fields = fs.fields();
+
+    if let Some(f) = fields.next() {
+        if fields.next().is_none() {
+            fs.bit_size == f.bit_size() && f.bit_offset().min_offset() == 0 && f.enumm().is_none()
+        } else {
+            false
+        }
+    } else {
+        true
     }
 }
 

--- a/src/transform/expand_extends.rs
+++ b/src/transform/expand_extends.rs
@@ -42,12 +42,12 @@ impl ExpandExtends {
             if let Some(parent_name) = &fieldset.extends {
                 let parent = get_ref!(ir, fieldsets, parent_name)?;
 
-                let items = parent.fields.clone();
+                let items: Vec<_> = parent.fields().cloned().collect();
                 let fieldset = get_mut!(ir, fieldsets, &name)?;
 
                 for i in items {
-                    if !fieldset.fields.iter().any(|j| j.name == i.name) {
-                        fieldset.fields.push(i);
+                    if !fieldset.fields().any(|j| j.name() == i.name()) {
+                        fieldset.push(i.into());
                     }
                 }
             }

--- a/src/transform/fix_register_bit_sizes.rs
+++ b/src/transform/fix_register_bit_sizes.rs
@@ -28,20 +28,20 @@ impl FixRegisterBitSizes {
                                 if self.create_fieldsets {
                                     // create a new fieldset, with a single field with the original bit size.
                                     r.fieldset = Some(i.name.clone());
-                                    let fs = FieldSet {
+                                    let fs = UnorderedFieldSet {
                                         bit_size: good_bit_size,
                                         fields: vec![Field {
                                             name: "val".to_string(),
+                                            description: None,
                                             bit_offset: BitOffset::Regular(0),
                                             bit_size: orig_bit_size,
-                                            description: None,
-                                            enumm: None,
                                             array: None,
+                                            enumm: None,
                                         }],
                                         description: None,
                                         extends: None,
                                     };
-                                    if ir.fieldsets.insert(i.name.clone(), fs).is_some() {
+                                    if ir.fieldsets.insert(i.name.clone(), fs.into()).is_some() {
                                         bail!("dup fieldset {}", i.name);
                                     }
                                 }

--- a/src/transform/make_field_array.rs
+++ b/src/transform/make_field_array.rs
@@ -18,17 +18,13 @@ impl MakeFieldArray {
     pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
         for id in match_all(ir.fieldsets.keys().cloned(), &self.fieldsets) {
             let b = get_mut!(ir, fieldsets, &id)?;
-            let groups = match_groups(
-                b.fields.iter().map(|f| f.name.clone()),
-                &self.from,
-                &self.to,
-            );
+            let groups = match_groups(b.fields().map(|f| f.name().clone()), &self.from, &self.to);
             for (to, group) in groups {
                 info!("arrayizing to {}", to);
 
                 // Grab all items into a vec
                 let mut items = Vec::new();
-                for i in b.fields.iter().filter(|i| group.contains(&i.name)) {
+                for i in b.fields().filter(|i| group.contains(i.name())) {
                     items.push(i);
                 }
 
@@ -38,11 +34,11 @@ impl MakeFieldArray {
                 {
                     let has_regular_bit_offset = items
                         .iter()
-                        .any(|i| matches!(i.bit_offset, BitOffset::Regular(_)));
+                        .any(|i| matches!(i.bit_offset(), BitOffset::Regular(_)));
 
                     let has_cursed_bit_offset = items
                         .iter()
-                        .any(|i| matches!(i.bit_offset, BitOffset::Cursed(_)));
+                        .any(|i| matches!(i.bit_offset(), BitOffset::Cursed(_)));
 
                     if has_regular_bit_offset && has_cursed_bit_offset {
                         bail!("arrayize: items {} cannot mix bit_offset type", to)
@@ -51,27 +47,25 @@ impl MakeFieldArray {
 
                 // todo check they're not arrays (arrays of arrays not supported)
 
-                // Sort by offs
-                items.sort_by_key(|i| &i.bit_offset);
                 for i in &items {
-                    info!("    {}", i.name);
+                    info!("    {}", i.name());
                 }
 
                 let (offset, array) = calc_array(
-                    items.iter().map(|x| x.bit_offset.min_offset()).collect(),
+                    items.iter().map(|x| x.bit_offset().min_offset()).collect(),
                     self.mode,
                 )?;
 
-                let mut item = items[0].clone();
+                let mut item = items[0].as_ref().clone();
 
                 // Remove all
-                b.fields.retain(|i| !group.contains(&i.name));
+                b.retain_fields(|i| !group.contains(i.name()));
 
                 // Create the new array item
                 item.name = to;
                 item.array = Some(array);
                 item.bit_offset = BitOffset::Regular(offset);
-                b.fields.push(item);
+                b.push(item);
             }
         }
         Ok(())

--- a/src/transform/merge_fieldsets.rs
+++ b/src/transform/merge_fieldsets.rs
@@ -150,81 +150,66 @@ impl std::fmt::Display for FieldSetError {
 pub(crate) fn fieldset_compat(main: &FieldSet, other: &FieldSet) -> Vec<FieldSetError> {
     let mut errors = Vec::new();
 
-    let FieldSet {
-        extends,
-        description,
-        bit_size,
-        fields,
-    } = main;
-
-    if extends.as_ref() != other.extends.as_ref() {
+    if main.extends != other.extends {
         errors.push(FieldSetError::Extends(
-            extends.clone(),
+            main.extends.clone(),
             other.extends.clone(),
         ));
     }
 
-    if *bit_size != other.bit_size {
-        errors.push(FieldSetError::Bitsize(*bit_size, other.bit_size));
+    if main.bit_size != other.bit_size {
+        errors.push(FieldSetError::Bitsize(main.bit_size, other.bit_size));
     }
 
-    if description.as_ref() != other.description.as_ref() {
+    if main.description != other.description {
         errors.push(FieldSetError::Description(
-            description.clone(),
+            main.description.clone(),
             other.description.clone(),
         ));
     }
 
-    for main in fields {
-        let Some(other) = other
-            .fields
-            .iter()
-            .find(|f| f.bit_offset == main.bit_offset)
-        else {
+    for main in main.fields() {
+        let Some(other) = other.fields().find(|f| f.bit_offset() == main.bit_offset()) else {
             errors.push(FieldSetError::RhsMissingField(
-                main.name.clone(),
-                MissingFieldReason::NoFieldAtOffset(main.bit_offset.clone()),
+                main.name().clone(),
+                MissingFieldReason::NoFieldAtOffset(main.bit_offset().clone()),
             ));
             continue;
         };
 
-        if main.bit_size != other.bit_size {
+        if main.bit_size() != other.bit_size() {
             errors.push(FieldSetError::RhsMissingField(
-                main.name.clone(),
-                MissingFieldReason::BitsizeMismatch(main.bit_size, other.bit_size),
+                main.name().clone(),
+                MissingFieldReason::BitsizeMismatch(main.bit_size(), other.bit_size()),
             ));
             continue;
         };
 
         errors.extend(
-            field_compat(&main, &other)
+            field_compat(main.as_ref(), other.as_ref())
                 .into_iter()
                 .map(|error| FieldSetError::Field {
-                    lhs_name: main.name.clone(),
-                    bit_offset: main.bit_offset.clone(),
-                    bit_size: main.bit_size,
+                    lhs_name: main.name().clone(),
+                    bit_offset: main.bit_offset().clone(),
+                    bit_size: main.bit_size(),
                     error,
                 }),
         );
     }
 
-    for other in other.fields.iter() {
-        let Some(main) = main
-            .fields
-            .iter()
-            .find(|f| f.bit_offset == other.bit_offset)
-        else {
+    for other in other.fields() {
+        let Some(main) = main.fields().find(|f| f.bit_offset() == other.bit_offset()) else {
             errors.push(FieldSetError::LhsMissingfield(
-                other.name.clone(),
-                MissingFieldReason::NoFieldAtOffset(other.bit_offset.clone()),
+                other.name().clone(),
+                MissingFieldReason::NoFieldAtOffset(other.bit_offset().clone()),
             ));
             continue;
         };
 
-        if main.bit_size != other.bit_size {
+        if main.bit_size() != other.bit_size() {
             errors.push(FieldSetError::LhsMissingfield(
-                other.name.clone(),
-                MissingFieldReason::BitsizeMismatch(main.bit_size, other.bit_size),
+                other.name().clone(),
+                MissingFieldReason::BitsizeMismatch(main.bit_size(), other.bit_size()),
             ));
         }
     }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -97,8 +97,8 @@ pub fn map_enum_names(ir: &mut IR, f: impl Fn(&mut String)) {
     remap_names(NameKind::Enum, &mut ir.enums, &f).unwrap();
 
     for (_, fs) in ir.fieldsets.iter_mut() {
-        for ff in fs.fields.iter_mut() {
-            rename_opt(&mut ff.enumm, &f);
+        for ff in fs.fields_mut() {
+            rename_opt(ff.enumm_opt_mut(), &f);
         }
     }
 }
@@ -133,9 +133,13 @@ pub fn map_block_item_names(ir: &mut IR, f: impl Fn(&mut String)) {
 
 pub fn map_field_names(ir: &mut IR, f: impl Fn(&mut String)) {
     for (_, fs) in ir.fieldsets.iter_mut() {
-        for ff in fs.fields.iter_mut() {
-            f(&mut ff.name)
+        let mut fields = fs.take_fields();
+
+        for ff in fields.iter_mut() {
+            f(&mut ff.name);
         }
+
+        fs.extend(fields);
     }
 }
 
@@ -173,8 +177,8 @@ pub fn map_descriptions(ir: &mut IR, mut ff: impl FnMut(&str) -> String) -> anyh
 
     for (_, fs) in ir.fieldsets.iter_mut() {
         mapit(&mut fs.description);
-        for f in fs.fields.iter_mut() {
-            mapit(&mut f.description);
+        for f in fs.fields_mut() {
+            mapit(f.description_opt_mut());
         }
     }
 

--- a/src/transform/modify_fields_enum.rs
+++ b/src/transform/modify_fields_enum.rs
@@ -31,10 +31,9 @@ impl ModifyFieldsEnum {
             };
 
             let fs = get_mut!(ir, fieldsets, &id)?;
-            fs.fields
-                .iter_mut()
-                .filter(|f| self.field.is_match(&f.name))
-                .for_each(|f| f.enumm = Some(enum_id.clone()));
+            fs.fields_mut()
+                .filter(|f| self.field.is_match(f.name()))
+                .for_each(|f| f.set_enumm(Some(enum_id.clone())));
         }
 
         Ok(())

--- a/src/transform/rename_fields.rs
+++ b/src/transform/rename_fields.rs
@@ -25,13 +25,17 @@ impl RenameFields {
 
             let fmt = |field| format!("field {field} in fieldset {id}");
 
-            for f in &mut fs.fields {
+            let mut fields = fs.take_fields();
+
+            for f in fields.iter_mut() {
                 if let Some(name) = match_expand(&f.name, &self.from, &self.to) {
                     had_duplicate |=
                         !can_rename(self.error_on_duplicate, renames, &name, &f.name, fmt);
                     f.name = name;
                 }
             }
+
+            fs.extend(fields);
         }
 
         if had_duplicate && self.error_on_duplicate {

--- a/src/transform/resize_enums.rs
+++ b/src/transform/resize_enums.rs
@@ -71,7 +71,10 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
     let fieldsets = ir
         .fieldsets
         .iter()
-        .filter(|(_, fs)| fs.fields.iter().any(|f| f.enumm.as_deref() == Some(enumm)))
+        .filter(|(_, fs)| {
+            fs.fields()
+                .any(|f| f.enumm().map(|v| v.as_str()) == Some(enumm))
+        })
         .map(|(name, _)| name)
         .cloned()
         .collect::<Vec<_>>();
@@ -82,27 +85,26 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
         let fs = ir.fieldsets.get_mut(&fs_name).unwrap();
 
         for field in fs
-            .fields
-            .iter_mut()
-            .filter(|f| f.enumm.as_deref() == Some(enumm))
+            .fields_mut()
+            .filter(|f| f.enumm().map(|v| v.as_str()) == Some(enumm))
         {
-            field.bit_size = bit_size;
+            field.set_bit_size(bit_size);
         }
 
         let mut error = false;
 
         // Verify there are no overlapping fields after resizing enums.
-        for (i1, i2) in Pairs::new(fs.fields.iter()) {
+        for (i1, i2) in Pairs::new(fs.fields()) {
             // expand every BitOffset to a Vec<RangeInclusive>,
             // and compare at that level
-            'COMPARE: for i1_range in i1.bit_offset.clone().into_ranges(i1.bit_size) {
-                for i2_range in i2.bit_offset.clone().into_ranges(i2.bit_size) {
+            'COMPARE: for i1_range in i1.bit_offset().clone().into_ranges(i1.bit_size()) {
+                for i2_range in i2.bit_offset().clone().into_ranges(i2.bit_size()) {
                     if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
                         log::error!(
                             "fieldset {}: fields overlap: {} {}",
                             fs_name,
-                            i1.name,
-                            i2.name
+                            i1.name(),
+                            i2.name()
                         );
                         error |= true;
                         break 'COMPARE;

--- a/src/transform/sort.rs
+++ b/src/transform/sort.rs
@@ -10,10 +10,7 @@ impl Sort {
         for z in ir.blocks.values_mut() {
             z.items.sort_by_key(|i| (i.byte_offset, i.name.clone()))
         }
-        for z in ir.fieldsets.values_mut() {
-            z.fields
-                .sort_by_key(|i| (i.bit_offset.clone(), i.name.clone()))
-        }
+
         for z in ir.enums.values_mut() {
             z.variants.sort_by_key(|i| (i.value, i.name.clone()))
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -175,7 +175,8 @@ pub fn relative_path(a: &str, b: &str) -> TokenStream {
     res
 }
 
-pub fn doc(doc: &Option<String>) -> TokenStream {
+pub fn doc<'a>(doc: impl Into<Option<&'a String>>) -> TokenStream {
+    let doc = doc.into();
     if let Some(doc) = doc {
         let doc = doc.replace("\\n", "\n");
         let doc = respace(&doc);

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -80,20 +80,20 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
             errs.push(format!("fieldset {} is unused", fsname));
         }
 
-        'FIELD: for f in &fs.fields {
-            if let Some(ename) = &f.enumm {
+        'FIELD: for f in fs.fields() {
+            if let Some(ename) = f.enumm() {
                 used_enums.insert(ename.clone());
 
                 let Some(e) = ir.enums.get(ename) else {
                     errs.push(format!(
                         "fieldset {} field {}: enum {} does not exist",
-                        fsname, f.name, ename
+                        fsname, f.name(), ename
                     ));
                     continue;
                 };
 
                 // do extra check when bit_offset is in "range mode"
-                if let BitOffset::Cursed(ranges) = &f.bit_offset {
+                if let BitOffset::Cursed(ranges) = &f.bit_offset() {
                     let mut last_max_index = 0;
                     let mut ranges_size = 0;
                     for (index, range) in ranges.iter().enumerate() {
@@ -101,7 +101,7 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                         if range.is_empty() {
                             errs.push(format!(
                                 "fieldset {} field {}: end value of bit_offset is bigger than start value",
-                                fsname, f.name,
+                                fsname, f.name(),
                             ));
                             continue 'FIELD;
                         }
@@ -112,14 +112,14 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                                 Ordering::Less => {
                                     errs.push(format!(
                                     "fieldset {} field {}: bit_offset is overlapped with itself",
-                                    fsname, f.name,
+                                    fsname, f.name(),
                                 ));
                                     continue 'FIELD;
                                 }
                                 Ordering::Equal => {
                                     errs.push(format!(
                                         "fieldset {} field {}: bit_offset has continuous part, should be merged",
-                                        fsname, f.name,
+                                        fsname, f.name(),
                                     ));
                                     continue 'FIELD;
                                 }
@@ -130,34 +130,34 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
                     }
 
                     // bit size from "ranges" should be the same as field bit_size
-                    if ranges_size != f.bit_size {
+                    if ranges_size != f.bit_size() {
                         errs.push(format!(
                             "fieldset {} field {}: size of bit_offset ranges is mismatch with field bit_size",
-                            fsname, f.name,
+                            fsname, f.name(),
                         ));
                         continue;
                     }
                 }
 
-                if f.bit_size != e.bit_size {
+                if f.bit_size() != e.bit_size {
                     errs.push(format!(
                         "fieldset {} field {}: bit_size {} does not match enum {} bit_size {}",
-                        fsname, f.name, f.bit_size, ename, e.bit_size
+                        fsname, f.name(), f.bit_size(), ename, e.bit_size
                     ));
                 }
             }
         }
 
         if !options.allow_field_overlap {
-            for (i1, i2) in Pairs::new(fs.fields.iter()) {
+            for (i1, i2) in Pairs::new(fs.fields()) {
                 // expand every BitOffset to a Vec<RangeInclusive>,
                 // and compare at that level
-                'COMPARE: for i1_range in i1.bit_offset.clone().into_ranges(i1.bit_size) {
-                    for i2_range in i2.bit_offset.clone().into_ranges(i2.bit_size) {
+                'COMPARE: for i1_range in i1.bit_offset().clone().into_ranges(i1.bit_size()) {
+                    for i2_range in i2.bit_offset().clone().into_ranges(i2.bit_size()) {
                         if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
                             errs.push(format!(
                                 "fieldset {}: fields overlap: {} {}",
-                                fsname, i1.name, i2.name
+                                fsname, i1.name(), i2.name()
                             ));
                             break 'COMPARE;
                         }


### PR DESCRIPTION
The functionality in `validate` and `ResizeEnums` that checks if fields are overlapping relies on the fact that fields are ordered by their `bit_offset`.

Since there is no machinery in place to prevent a transform (such as `AddFields`) from inserting fields out-of-order, the validation performed by `ResizeEnums` may become false-negative depending on transforms that were running before it.

This PR enforces the ordering that some parts of the code relied on by making the `FieldSet::fields` field private and enforcing that all access and modifications cannot change the order.

This does add quite a bit of code, but it'll make transforms and the tool overall more predictable.