### PR TITLE
validate & resize_enums: sort fields before checking overlap

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -36,8 +36,8 @@ pub fn check(args: Check) -> Result<()> {
 
     for file in args.files {
         let got_data = fs::read(&file)?;
-        let ir: IR = serde_yaml::from_slice(&got_data)?;
-        let errs = crate::validate::validate(&ir, opts.clone());
+        let mut ir: IR = serde_yaml::from_slice(&got_data)?;
+        let errs = crate::validate::validate(&mut ir, opts.clone());
         fails += errs.len();
         for e in errs {
             println!("{}: {}", file.display(), e);

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -175,6 +175,34 @@ pub struct FieldSet {
     pub fields: Vec<Field>,
 }
 
+impl FieldSet {
+    pub fn sort_fields(&mut self) {
+        self.fields
+            .sort_by(|a, b| a.bit_offset.cmp(&b.bit_offset).then(a.name.cmp(&b.name)))
+    }
+
+    pub fn overlapping_fields(&mut self) -> impl Iterator<Item = (&Field, &Field)> {
+        self.sort_fields();
+
+        self.fields.array_windows().flat_map(move |[i1, i2]| {
+            // expand every BitOffset to a Vec<RangeInclusive>,
+            // and compare at that level
+            let mut i1_ranges = i1.bit_offset.clone().into_ranges(i1.bit_size).into_iter();
+            i1_ranges.find_map(move |i1_range| {
+                let i2_ranges = i2.bit_offset.clone().into_ranges(i2.bit_size).into_iter();
+
+                i2_ranges.clone().find_map(move |i2_range| {
+                    if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
+                        Some((i1, i2))
+                    } else {
+                        None
+                    }
+                })
+            })
+        })
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Eq)]
 #[serde(untagged)]
 pub enum BitOffset {

--- a/src/svd2ir.rs
+++ b/src/svd2ir.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 use clap::ValueEnum;
 use log::*;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/transform/resize_enums.rs
+++ b/src/transform/resize_enums.rs
@@ -89,17 +89,15 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
             field.bit_size = bit_size;
         }
 
-        let mut error = false;
-
         // Verify there are no overlapping fields after resizing enums.
-        fs.overlapping_fields().for_each(|(i1, i2)| {
+        let error = fs.overlapping_fields().fold(false, |_, (i1, i2)| {
             log::error!(
                 "fieldset {}: fields overlap: {} {}",
                 fs_name,
                 i1.name,
                 i2.name
             );
-            error |= true;
+            true
         });
 
         if error {

--- a/src/transform/resize_enums.rs
+++ b/src/transform/resize_enums.rs
@@ -92,24 +92,15 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
         let mut error = false;
 
         // Verify there are no overlapping fields after resizing enums.
-        for (i1, i2) in Pairs::new(fs.fields.iter()) {
-            // expand every BitOffset to a Vec<RangeInclusive>,
-            // and compare at that level
-            'COMPARE: for i1_range in i1.bit_offset.clone().into_ranges(i1.bit_size) {
-                for i2_range in i2.bit_offset.clone().into_ranges(i2.bit_size) {
-                    if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
-                        log::error!(
-                            "fieldset {}: fields overlap: {} {}",
-                            fs_name,
-                            i1.name,
-                            i2.name
-                        );
-                        error |= true;
-                        break 'COMPARE;
-                    }
-                }
-            }
-        }
+        fs.overlapping_fields().for_each(|(i1, i2)| {
+            log::error!(
+                "fieldset {}: fields overlap: {} {}",
+                fs_name,
+                i1.name,
+                i2.name
+            );
+            error |= true;
+        });
 
         if error {
             bail!("Fields overlap in {enumm}");
@@ -117,45 +108,4 @@ fn update_uses(ir: &mut IR, enumm: &str) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-struct Pairs<U: Iterator + Clone> {
-    head: Option<U::Item>,
-    tail: U,
-    next: U,
-}
-
-impl<U: Iterator + Clone> Pairs<U> {
-    fn new(mut iter: U) -> Self {
-        let head = iter.next();
-        Pairs {
-            head,
-            tail: iter.clone(),
-            next: iter,
-        }
-    }
-}
-
-impl<U: Iterator + Clone> Iterator for Pairs<U>
-where
-    U::Item: Clone,
-{
-    type Item = (U::Item, U::Item);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let a = self.head.as_ref()?.clone();
-
-        if let Some(b) = self.tail.next() {
-            return Some((a, b));
-        }
-
-        match self.next.next() {
-            Some(new_head) => {
-                self.head = Some(new_head);
-                self.tail = self.next.clone();
-                self.next()
-            }
-            None => None,
-        }
-    }
 }

--- a/src/transform/sort.rs
+++ b/src/transform/sort.rs
@@ -11,8 +11,7 @@ impl Sort {
             z.items.sort_by_key(|i| (i.byte_offset, i.name.clone()))
         }
         for z in ir.fieldsets.values_mut() {
-            z.fields
-                .sort_by_key(|i| (i.bit_offset.clone(), i.name.clone()))
+            z.sort_fields();
         }
         for z in ir.enums.values_mut() {
             z.variants.sort_by_key(|i| (i.value, i.name.clone()))

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -11,7 +11,7 @@ pub struct Options {
     pub allow_unused_fieldsets: bool,
 }
 
-pub fn validate(ir: &IR, options: Options) -> Vec<String> {
+pub fn validate(ir: &mut IR, options: Options) -> Vec<String> {
     let mut errs = Vec::new();
 
     let mut used_fieldsets = BTreeSet::new();
@@ -75,7 +75,7 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
         }
     }
 
-    for (fsname, fs) in &ir.fieldsets {
+    for (fsname, fs) in &mut ir.fieldsets {
         if !options.allow_unused_fieldsets && !used_fieldsets.contains(fsname) {
             errs.push(format!("fieldset {} is unused", fsname));
         }
@@ -149,21 +149,12 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
         }
 
         if !options.allow_field_overlap {
-            for (i1, i2) in Pairs::new(fs.fields.iter()) {
-                // expand every BitOffset to a Vec<RangeInclusive>,
-                // and compare at that level
-                'COMPARE: for i1_range in i1.bit_offset.clone().into_ranges(i1.bit_size) {
-                    for i2_range in i2.bit_offset.clone().into_ranges(i2.bit_size) {
-                        if i2_range.end() > i1_range.start() && i1_range.end() > i2_range.start() {
-                            errs.push(format!(
-                                "fieldset {}: fields overlap: {} {}",
-                                fsname, i1.name, i2.name
-                            ));
-                            break 'COMPARE;
-                        }
-                    }
-                }
-            }
+            fs.overlapping_fields().for_each(|(i1, i2)| {
+                errs.push(format!(
+                    "fieldset {}: fields overlap: {} {}",
+                    fsname, i1.name, i2.name
+                ));
+            });
         }
     }
 
@@ -199,14 +190,14 @@ pub fn validate(ir: &IR, options: Options) -> Vec<String> {
 
 // ==============
 
-struct Pairs<U: Iterator + Clone> {
+pub(crate) struct Pairs<U: Iterator + Clone> {
     head: Option<U::Item>,
     tail: U,
     next: U,
 }
 
 impl<U: Iterator + Clone> Pairs<U> {
-    fn new(mut iter: U) -> Self {
+    pub fn new(mut iter: U) -> Self {
         let head = iter.next();
         Pairs {
             head,


### PR DESCRIPTION
Previously, neither `validate` nor `resize_enums` checked whether fields of fieldsets were in sorted order before attempting to check them for overlap.

We can put the overlap-checking functionality in a function and use that in the relevant places.

Follow-up to #134 