### PR TITLE
Add _iter and _len methods to block and fieldset arrays

### DIFF
--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -46,13 +46,20 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
 
                 let ty = quote!(#common_path::Reg<#reg_ty, #access>);
                 if let Some(array) = &i.array {
-                    let (len, offs_expr) = super::process_array(array);
+                    let super::ArrayDescription {
+                        array_ty,
+                        constructor,
+                    } = super::process_ptr_array(
+                        array,
+                        &quote!(self.ptr.wrapping_add(#offset)),
+                        &ty,
+                        &common_path,
+                    );
                     items.extend(quote!(
                         #doc
                         #[inline(always)]
-                        pub const fn #name(self, n: usize) -> #ty {
-                            assert!(n < #len);
-                            unsafe { #common_path::Reg::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
+                        pub const fn #name(self) -> #array_ty {
+                            #constructor
                         }
                     ));
                 } else {
@@ -74,14 +81,21 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
 
                 let ty = util::relative_path(block_path, path);
                 if let Some(array) = &i.array {
-                    let (len, offs_expr) = super::process_array(array);
+                    let super::ArrayDescription {
+                        array_ty,
+                        constructor,
+                    } = super::process_ptr_array(
+                        array,
+                        &quote!(self.ptr.wrapping_add(#offset)),
+                        &ty,
+                        &common_path,
+                    );
 
                     items.extend(quote!(
                         #doc
                         #[inline(always)]
-                        pub const fn #name(self, n: usize) -> #ty {
-                            assert!(n < #len);
-                            unsafe { #ty::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
+                        pub const fn #name(self) -> #array_ty {
+                            #constructor
                         }
                     ));
                 } else {
@@ -122,6 +136,12 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
             }
 
             #items
+        }
+
+        impl #common_path::FromPtr for #name {
+            unsafe fn from_ptr(ptr: *mut u8) -> Self {
+                unsafe { #name::from_ptr(ptr as *mut ()) }
+            }
         }
     };
 

--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -16,8 +16,6 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
 
     for i in sorted(&b.items, |i| (i.byte_offset, i.name.clone())) {
         let name = Ident::new(&i.name, span);
-        let name_iter = Ident::new(&format!("{}_iter", i.name), span);
-        let name_len = Ident::new(&format!("{}_len", i.name), span);
         let offset = util::hex_usize(i.byte_offset as u64);
 
         let doc = util::doc(&i.description);
@@ -56,18 +54,6 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                             assert!(n < #len);
                             unsafe { #common_path::Reg::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
                         }
-
-                        #doc
-                        #[inline(always)]
-                        pub fn #name_iter(self) -> impl Iterator<Item = #ty> {
-                            (0..#len).map(move |i| self.#name(i))
-                        }
-
-                        #doc
-                        #[inline(always)]
-                        pub const fn #name_len(self) -> usize {
-                            #len
-                        }
                     ));
                 } else {
                     items.extend(quote!(
@@ -96,18 +82,6 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         pub const fn #name(self, n: usize) -> #ty {
                             assert!(n < #len);
                             unsafe { #ty::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
-                        }
-
-                        #doc
-                        #[inline(always)]
-                        pub fn #name_iter(self) -> impl Iterator<Item = #ty> {
-                            (0..#len).map(move |i| self.#name(i))
-                        }
-
-                        #doc
-                        #[inline(always)]
-                        pub const fn #name_len(self) -> usize {
-                            #len
                         }
                     ));
                 } else {

--- a/src/generate/block.rs
+++ b/src/generate/block.rs
@@ -16,6 +16,8 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
 
     for i in sorted(&b.items, |i| (i.byte_offset, i.name.clone())) {
         let name = Ident::new(&i.name, span);
+        let name_iter = Ident::new(&format!("{}_iter", i.name), span);
+        let name_len = Ident::new(&format!("{}_len", i.name), span);
         let offset = util::hex_usize(i.byte_offset as u64);
 
         let doc = util::doc(&i.description);
@@ -54,6 +56,18 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                             assert!(n < #len);
                             unsafe { #common_path::Reg::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
                         }
+
+                        #doc
+                        #[inline(always)]
+                        pub fn #name_iter(self) -> impl Iterator<Item = #ty> {
+                            (0..#len).map(move |i| self.#name(i))
+                        }
+
+                        #doc
+                        #[inline(always)]
+                        pub const fn #name_len(self) -> usize {
+                            #len
+                        }
                     ));
                 } else {
                     items.extend(quote!(
@@ -82,6 +96,18 @@ pub fn render(opts: &super::Options, ir: &IR, b: &Block, path: &str) -> Result<T
                         pub const fn #name(self, n: usize) -> #ty {
                             assert!(n < #len);
                             unsafe { #ty::from_ptr(self.ptr.wrapping_add(#offset + #offs_expr) as _) }
+                        }
+
+                        #doc
+                        #[inline(always)]
+                        pub fn #name_iter(self) -> impl Iterator<Item = #ty> {
+                            (0..#len).map(move |i| self.#name(i))
+                        }
+
+                        #doc
+                        #[inline(always)]
+                        pub const fn #name_len(self) -> usize {
+                            #len
                         }
                     ));
                 } else {

--- a/src/generate/common.rs
+++ b/src/generate/common.rs
@@ -83,3 +83,126 @@ impl<T: Copy, A: Read + Write> Reg<T, A> {
         self.write_value(val);
     }
 }
+
+pub trait FromPtr: Copy {
+    unsafe fn from_ptr(ptr: *mut u8) -> Self;
+}
+
+impl<T: Copy, A: Access> FromPtr for Reg<T, A> {
+    unsafe fn from_ptr(ptr: *mut u8) -> Self {
+        unsafe { Reg::<T, A>::from_ptr(ptr as *mut T) }
+    }
+}
+
+pub struct Array<T> {
+    ptr: *mut u8,
+    stride: usize,
+    len: usize,
+    _type: PhantomData<T>,
+}
+
+impl<T: Clone> Clone for Array<T> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            stride: self.stride,
+            len: self.len,
+            _type: self._type,
+        }
+    }
+}
+impl<T: Copy> Copy for Array<T> {}
+
+impl<T> Array<T> {
+    #[inline(always)]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T: FromPtr> Array<T> {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut u8, stride: usize, len: usize) -> Self {
+        Self {
+            ptr,
+            stride,
+            len,
+            _type: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get(&self, n: usize) -> T {
+        assert!(n < self.len());
+        unsafe { T::from_ptr(self.ptr.wrapping_add(n * self.stride)) }
+    }
+}
+
+impl<T: FromPtr> Iterator for Array<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len == 0 {
+            return None;
+        }
+
+        self.ptr = self.ptr.wrapping_add(self.stride);
+        self.len -= 1;
+
+        Some(self.get(0))
+    }
+}
+
+pub struct CursedArray<T> {
+    ptr: *mut u8,
+    offsets: &'static [usize],
+    _type: PhantomData<T>,
+}
+
+impl<T: Clone> Clone for CursedArray<T> {
+    fn clone(&self) -> Self {
+        Self {
+            ptr: self.ptr,
+            offsets: self.offsets,
+            _type: self._type,
+        }
+    }
+}
+impl<T: Copy> Copy for CursedArray<T> {}
+
+impl<T> CursedArray<T> {
+    #[inline(always)]
+    pub const fn len(&self) -> usize {
+        self.offsets.len()
+    }
+}
+
+impl<T: FromPtr> CursedArray<T> {
+    #[inline(always)]
+    pub const unsafe fn from_ptr(ptr: *mut u8, offsets: &'static [usize]) -> Self {
+        Self {
+            ptr,
+            offsets,
+            _type: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get(&self, n: usize) -> T {
+        assert!(n < self.len());
+        unsafe { T::from_ptr(self.ptr.wrapping_add(self.offsets[n])) }
+    }
+}
+
+impl<T: FromPtr> Iterator for CursedArray<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len() == 0 {
+            return None;
+        }
+
+        self.offsets = &self.offsets[1..];
+        Some(self.get(0))
+    }
+}

--- a/src/generate/common.rs
+++ b/src/generate/common.rs
@@ -146,10 +146,12 @@ impl<T: FromPtr> Iterator for Array<T> {
             return None;
         }
 
+        let el = self.get(0);
+
         self.ptr = self.ptr.wrapping_add(self.stride);
         self.len -= 1;
 
-        Some(self.get(0))
+        Some(el)
     }
 }
 
@@ -202,7 +204,8 @@ impl<T: FromPtr> Iterator for CursedArray<T> {
             return None;
         }
 
+        let el = self.get(0);
         self.offsets = &self.offsets[1..];
-        Some(self.get(0))
+        Some(el)
     }
 }

--- a/src/generate/common.rs
+++ b/src/generate/common.rs
@@ -101,6 +101,10 @@ pub struct Array<T> {
     _type: PhantomData<T>,
 }
 
+pub struct ArrayIter<T> {
+    parent: T,
+}
+
 impl<T: Clone> Clone for Array<T> {
     fn clone(&self) -> Self {
         Self {
@@ -138,19 +142,26 @@ impl<T: FromPtr> Array<T> {
     }
 }
 
-impl<T: FromPtr> Iterator for Array<T> {
+impl<T: FromPtr> IntoIterator for Array<T> {
+    type Item = T;
+    type IntoIter = ArrayIter<Array<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ArrayIter { parent: self }
+    }
+}
+
+impl<T: FromPtr> Iterator for ArrayIter<Array<T>> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.len == 0 {
+        if self.parent.len == 0 {
             return None;
         }
 
-        let el = self.get(0);
-
-        self.ptr = self.ptr.wrapping_add(self.stride);
-        self.len -= 1;
-
+        let el = self.parent.get(0);
+        self.parent.ptr = self.parent.ptr.wrapping_add(self.parent.stride);
+        self.parent.len -= 1;
         Some(el)
     }
 }
@@ -196,16 +207,25 @@ impl<T: FromPtr> CursedArray<T> {
     }
 }
 
-impl<T: FromPtr> Iterator for CursedArray<T> {
+impl<T: FromPtr> IntoIterator for CursedArray<T> {
+    type Item = T;
+    type IntoIter = ArrayIter<CursedArray<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ArrayIter { parent: self }
+    }
+}
+
+impl<T: FromPtr> Iterator for ArrayIter<CursedArray<T>> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.len() == 0 {
+        if self.parent.len() == 0 {
             return None;
         }
 
-        let el = self.get(0);
-        self.offsets = &self.offsets[1..];
+        let el = self.parent.get(0);
+        self.parent.offsets = &self.parent.offsets[1..];
         Some(el)
     }
 }

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -26,6 +26,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
     for f in sorted(&fs.fields, |f| (f.bit_offset.clone(), f.name.clone())) {
         let name = Ident::new(&f.name, span);
         let name_set = Ident::new(&format!("set_{}", f.name), span);
+        let name_len = Ident::new(&format!("{}_len", f.name), span);
         let off_in_reg = f.bit_offset.clone();
         let _bit_size = f.bit_size as usize;
         let mask = util::hex(1u64.wrapping_shl(f.bit_size).wrapping_sub(1));
@@ -88,12 +89,20 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                         #doc
                         #[must_use]
                         #[inline(always)]
-                        pub const fn #name(&self, n: usize) -> #field_ty{
+                        pub const fn #name(&self, n: usize) -> #field_ty {
                             assert!(n < #len);
                             let offs = #off_in_reg + #offs_expr;
                             let val = (self.0 >> offs) & #mask;
                             #from_bits
                         }
+
+                        #doc
+                        #[must_use]
+                        #[inline(always)]
+                        pub const fn #name_len(&self) -> usize {
+                            #len
+                        }
+
                         #doc
                         #[inline(always)]
                         pub const fn #name_set(&mut self, n: usize, val: #field_ty) {
@@ -154,6 +163,14 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                                 val += (((self.0 >> offs) & #mask) << #off_in_val); )*;
                             #from_bits
                         }
+
+                        #doc
+                        #[must_use]
+                        #[inline(always)]
+                        pub const fn #name_len(&self) -> usize {
+                            #len
+                        }
+
                         #doc
                         #[inline(always)]
                         pub const fn #name_set(&mut self, n: usize, val: #field_ty) {

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -26,7 +26,6 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
     for f in sorted(&fs.fields, |f| (f.bit_offset.clone(), f.name.clone())) {
         let name = Ident::new(&f.name, span);
         let name_set = Ident::new(&format!("set_{}", f.name), span);
-        let name_len = Ident::new(&format!("{}_len", f.name), span);
         let off_in_reg = f.bit_offset.clone();
         let _bit_size = f.bit_size as usize;
         let mask = util::hex(1u64.wrapping_shl(f.bit_size).wrapping_sub(1));
@@ -89,20 +88,12 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                         #doc
                         #[must_use]
                         #[inline(always)]
-                        pub const fn #name(&self, n: usize) -> #field_ty {
+                        pub const fn #name(&self, n: usize) -> #field_ty{
                             assert!(n < #len);
                             let offs = #off_in_reg + #offs_expr;
                             let val = (self.0 >> offs) & #mask;
                             #from_bits
                         }
-
-                        #doc
-                        #[must_use]
-                        #[inline(always)]
-                        pub const fn #name_len(&self) -> usize {
-                            #len
-                        }
-
                         #doc
                         #[inline(always)]
                         pub const fn #name_set(&mut self, n: usize, val: #field_ty) {
@@ -163,14 +154,6 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                                 val += (((self.0 >> offs) & #mask) << #off_in_val); )*;
                             #from_bits
                         }
-
-                        #doc
-                        #[must_use]
-                        #[inline(always)]
-                        pub const fn #name_len(&self) -> usize {
-                            #len
-                        }
-
                         #doc
                         #[inline(always)]
                         pub const fn #name_set(&mut self, n: usize, val: #field_ty) {

--- a/src/generate/fieldset.rs
+++ b/src/generate/fieldset.rs
@@ -26,6 +26,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
     for f in sorted(&fs.fields, |f| (f.bit_offset.clone(), f.name.clone())) {
         let name = Ident::new(&f.name, span);
         let name_set = Ident::new(&format!("set_{}", f.name), span);
+        let name_len = Ident::new(&format!("{}_len", f.name), span);
         let off_in_reg = f.bit_offset.clone();
         let _bit_size = f.bit_size as usize;
         let mask = util::hex(1u64.wrapping_shl(f.bit_size).wrapping_sub(1));
@@ -83,7 +84,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
             BitOffset::Regular(off_in_reg) => {
                 let off_in_reg = off_in_reg as usize;
                 if let Some(array) = &f.array {
-                    let (len, offs_expr) = super::process_array(array);
+                    let (len, offs_expr) = super::process_field_array(array);
                     items.extend(quote!(
                         #doc
                         #[must_use]
@@ -100,6 +101,11 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                             assert!(n < #len);
                             let offs = #off_in_reg + #offs_expr;
                             self.0 = (self.0 & !(#mask << offs)) | (((#to_bits) & #mask) << offs);
+                        }
+                        #doc
+                        #[inline(always)]
+                        pub const fn #name_len(&self) -> usize {
+                            #len
                         }
                     ));
                 } else {
@@ -142,7 +148,7 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                 }
 
                 if let Some(array) = &f.array {
-                    let (len, offs_expr) = super::process_array(array);
+                    let (len, offs_expr) = super::process_field_array(array);
                     items.extend(quote!(
                         #doc
                         #[must_use]
@@ -160,6 +166,11 @@ pub fn render(opts: &super::Options, ir: &IR, fs: &FieldSet, path: &str) -> Resu
                             assert!(n < #len);
                             #( let offs = #off_in_reg + #offs_expr;
                                self.0 = (self.0 & !(#mask << offs)) | (((#to_bits >> #off_in_val) & #mask) << offs); )*;
+                        }
+                        #doc
+                        #[inline(always)]
+                        pub const fn #name_len(&self) -> usize {
+                            #len
                         }
                     ));
                 } else {

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -227,6 +227,40 @@ fn split_path(s: &str) -> (Vec<&str>, &str) {
     (v, n)
 }
 
+struct ArrayDescription {
+    array_ty: TokenStream,
+    constructor: TokenStream,
+}
+
+fn process_ptr_array(
+    array: &Array,
+    ptr: &TokenStream,
+    ty: &TokenStream,
+    common_path: &TokenStream,
+) -> ArrayDescription {
+    match array {
+        Array::Regular(array) => {
+            let len = array.len as usize;
+            let stride = array.stride as usize;
+            ArrayDescription {
+                array_ty: quote!(#common_path::Array<#ty>),
+                constructor: quote!(unsafe { #common_path::Array::from_ptr(#ptr, #stride, #len) }),
+            }
+        }
+        Array::Cursed(array) => {
+            let offsets = array
+                .offsets
+                .iter()
+                .map(|&x| x as usize)
+                .collect::<Vec<_>>();
+            ArrayDescription {
+                array_ty: quote!(#common_path::CursedArray<#ty>),
+                constructor: quote!(unsafe { #common_path::CursedArray::from_ptr(#ptr, &[#(#offsets),*]) }),
+            }
+        }
+    }
+}
+
 fn process_array(array: &Array) -> (usize, TokenStream) {
     match array {
         Array::Regular(array) => {

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,5 +1,4 @@
 mod block;
-mod common;
 mod device;
 mod enumm;
 mod fieldset;
@@ -262,7 +261,7 @@ fn process_ptr_array(
     }
 }
 
-fn process_array(array: &Array) -> (usize, TokenStream) {
+fn process_field_array(array: &Array) -> (usize, TokenStream) {
     match array {
         Array::Regular(array) => {
             let len = array.len as usize;

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,4 +1,5 @@
 mod block;
+mod common;
 mod device;
 mod enumm;
 mod fieldset;


### PR DESCRIPTION
Arrays in blocks and fieldsets result in accessors being generated with an index argument. This argument is then checked in an assert-block, which is only checked in debug builds typically. The amount of elements though is not emitted as of yet. Hence it requires HAL implementors to define a constant themselves. If for whatever reason the amount of elements changes, the code thus is incorrect.

We could add methods like `_len` to denote the number of elements. We could also add `_iter` to conveniently allow the user to iterate over every element. For fieldsets an iterator is not a straightforward API. I considered adding a callback interface for this, but for now I did not add it.

Unsure whether this is actually in line with what we want from chiptool, as we tend to favor 'light and simple' code per my understanding. I am very happy to discuss what is a good API to achieve similar results.

