### PR TITLE
Add RenameFieldsets transform

### DIFF
--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -271,4 +271,5 @@ transforms!(
     rename_interrupts::RenameInterrupts,
     rename_peripherals::RenamePeripherals,
     clean_descriptions::CleanDescriptions,
+    rename_fieldsets::RenameFieldsets,
 );

--- a/src/transform/rename_fieldsets.rs
+++ b/src/transform/rename_fieldsets.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::common::*;
+use crate::ir::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RenameFieldsets {
+    pub from: RegexSet,
+    pub to: String,
+}
+
+impl RenameFieldsets {
+    pub fn run(&self, ir: &mut IR) -> anyhow::Result<()> {
+        let mut renames = HashMap::new();
+        let mut mapping = HashMap::new();
+        let mut had_duplicate = false;
+
+        for id in match_all(ir.fieldsets.keys().cloned(), &self.from) {
+            let renames = renames.entry(id.clone()).or_default();
+
+            let fmt = |id| format!("fieldset {id}");
+
+            if let Some(name) = match_expand(&id, &self.from, &self.to) {
+                let can_rename = can_rename(true, renames, &name, &id, fmt);
+                had_duplicate |= !can_rename;
+
+                if can_rename {
+                    log::info!("Renaming fieldset '{}' to '{}'", id, name);
+                }
+
+                let removed = ir.fieldsets.remove(&id).expect("Match should be in set");
+                ir.fieldsets.insert(name.clone(), removed);
+                mapping.insert(id.clone(), name.clone());
+            }
+        }
+
+        ir.blocks
+            .iter_mut()
+            .flat_map(|(_, b)| b.items.iter_mut())
+            .filter_map(|i| match &mut i.inner {
+                BlockItemInner::Block(_) => None,
+                BlockItemInner::Register(register) => Some(register),
+            })
+            .for_each(|r| {
+                let Some(fieldset) = r.fieldset.as_mut() else {
+                    return;
+                };
+
+                let Some(new_name) = mapping.get(fieldset) else {
+                    return;
+                };
+
+                *fieldset = new_name.clone();
+            });
+
+        if had_duplicate {
+            anyhow::bail!("Duplicate use of new names");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
For more context, see: https://github.com/embassy-rs/chiptool/pull/136#issuecomment-4300799424

The core issue is that when trying to generate unique names, we must use _something_ to delimit the names. Underscores seems most sensible (alternatives are random-looking numbers at the end of strings, other random text). However, those unique names (i.e. `CFDRMDF_12` and `CFDRMDF_1_2`) resolve to the same sanitized name (`Cfdrmfd12`). We have no way to not do that, assuming the following alternatives (and why I think they don't solve the problem) aren't preferable:

1. When `Sanitize`-ing, remove `_` as boundary, but only for fieldsets (lots more ugly names, weird special-casing for fieldset names)
2. Force the `chiptool` user to `MergeFieldsets` on non-sanitized fieldsets (has exceptions: there's nothing preventing similarly-named fieldsets from being entirely different, so we may be forced to `RenameFieldsets`)
3. Just get rid of them with `DeleteFieldsets` (prevents user from using certain fieldsets, quite sucky)
4. Find a different way to generate unique names that doesn't cause issues during `Sanitize` (how? Most (all?) other non-text characters are stripped when casing to `PascalCase`, so whatever we pick, it won't work)
5. Don't deduplicate names in `svd2ir`: we can, of course, generate individual `FieldSet`s for each `dim`. Then fieldset names will be unique by SVD spec/requirement. (this throws away useful info directly provided by the SVD (= certain regs are identical), and forces users to `MergeFieldsets` on fieldsets that the SVD already tells us are identical.)

With `RenameFieldsets`, we don't have to do any additional special-casing. Just force the user to pick good names in case the ones uniquely generated by `svd2ir` are not immediately sanitizable.