### PR TITLE
extract_all: sanitize ':' out of block-name filenames for Windows

### DIFF
--- a/src/commands/extract_all.rs
+++ b/src/commands/extract_all.rs
@@ -67,6 +67,7 @@ fn extract_per_peripheral(extract_shared: &ExtractShared, output_dir: &Path) -> 
                     .keys()
                     .reduce(|acc, val| if val.len() < acc.len() { val } else { acc })
                     .unwrap()
+                    .replace("::", "__")
             )))?;
         serde_yaml::to_writer(f, &ir).unwrap();
     }
@@ -97,7 +98,9 @@ fn extract_per_block(extract_shared: &ExtractShared, output_dir: &Path) -> Resul
     for block_name in blocks {
         let block_ir = extract_relevant(&block_name, &ir)?;
 
-        let f = File::create(PathBuf::from(output_dir).join(format!("{}.yaml", block_name)))?;
+        let f = File::create(
+            PathBuf::from(output_dir).join(format!("{}.yaml", block_name.replace("::", "__"))),
+        )?;
         serde_yaml::to_writer(f, &block_ir).unwrap();
     }
 


### PR DESCRIPTION
NTFS treats ':' as the alternate-data-stream separator, so File::create rejects names like 'flexspi0::Flexspi0.yaml' with ERROR_INVALID_NAME (123). Replace '::' with '__' when forming on-disk filenames in extract_per_block (and the analogous shortest-name path in extract_per_namespace). The downstream nxp-pac post-processing strips the namespace from the filename anyway, so the new separator is transparent there.