### PR TITLE
add cortex-m-types interrupt number trait generation

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -22,6 +22,7 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
     let span = Span::call_site();
 
     let mut interrupts = TokenStream::new();
+    let mut from_arms = TokenStream::new();
     let mut peripherals = TokenStream::new();
     let mut vectors = TokenStream::new();
     let mut names = vec![];
@@ -47,6 +48,10 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
         );
 
         let value = util::unsuffixed(i.value as u64);
+
+        from_arms.extend(quote! {
+            #value => Ok(Interrupt::#name_uc),
+        });
 
         interrupts.extend(quote! {
             #[doc = #description]
@@ -76,10 +81,12 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
             });
         }
     }
-    let n = util::unsuffixed(pos as u64);
+    let num_of_interrupts = pos as u64;
+    let num_of_interrupts_unsuffixed = util::unsuffixed(num_of_interrupts as u64);
 
     let derive_defmt = with_defmt_cfg_attr(&opts.defmt, quote! { derive(defmt::Format) });
 
+    let max_interrupt_number = num_of_interrupts.saturating_sub(1);
     out.extend(quote!(
         #[derive(Copy, Clone, Debug, PartialEq, Eq)]
         #derive_defmt
@@ -91,6 +98,31 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
             #[inline(always)]
             fn number(self) -> u16 {
                 self as u16
+            }
+        }
+
+        unsafe impl cortex_m_types::InterruptNumber for Interrupt {
+            const MAX_INTERRUPT_NUMBER: usize = #max_interrupt_number;
+
+            #[inline(always)]
+            fn number(self) -> usize {
+                self as usize
+            }
+
+            /// Tries to convert a number to a valid interrupt.
+            #[inline]
+            fn from_number(value: usize) -> cortex_m_types::result::Result<Self> {
+                if value > Self::MAX_INTERRUPT_NUMBER {
+                    return Err(cortex_m_types::result::Error::IndexOutOfBounds {
+                        index: value,
+                        min: 0,
+                        max: Self::MAX_INTERRUPT_NUMBER,
+                    });
+                }
+                match value {
+                    #from_arms
+                    _ => Err(cortex_m_types::result::Error::InvalidVariant(value)),
+                }
             }
         }
 
@@ -107,7 +139,7 @@ pub fn render(opts: &super::Options, ir: &IR, d: &Device, path: &str) -> Result<
 
             #[unsafe(link_section = ".vector_table.interrupts")]
             #[unsafe(no_mangle)]
-            pub static __INTERRUPTS: [Vector; #n] = [
+            pub static __INTERRUPTS: [Vector; #num_of_interrupts_unsuffixed] = [
                 #vectors
             ];
         }


### PR DESCRIPTION
Generated crates need the `cortex-m-types` dependency. I tried to test this with https://github.com/embassy-rs/nrf-pac but I was not able to fully generate the crate with `update.sh` with a path installed `chiptool` , which failed with this error:

```rust
[2026-05-03T21:33:43Z INFO  chiptool::commands] running RenameFields(RenameFields { fieldset: RegexSet { include: [Regex("^.*::regs::Shorts.*$")], exclude: [] }, from: RegexSet { include: [Regex("^loopsdone_seqstart0$")], exclude: [] }, to: "loopsdone_dma_seq0_start", error_on_duplicate: true })
+ rustfmt lib.rs
+ sed -i '/#!\[no_std]/d' lib.rs
+ mkdir -p src/chips/nrf52811
+ mv lib.rs src/chips/nrf52811/pac.rs
+ mv device.x src/chips/nrf52811/device.x
+ for chip in $(ls svd)
+ chip=nrf52820
+ [[ nrf52820 == *nrf54* ]]
+ ../chiptool/target/release/chiptool generate --svd svd/nrf52820.svd --transform transform-compat.yaml
Error: converting svd at svd/nrf52820.svd

Caused by:
    Failed to find unique name for ["ACL"]. n: ["ACL"]

Stack backtrace:
   0: chiptool::svd2ir::unique_names
   1: chiptool::svd2ir::convert_peripheral
   2: chiptool::svd2ir::convert_svd
   3: chiptool::commands::generate::generate
   4: chiptool::main
   5: std::sys::backtrace::__rust_begin_short_backtrace
   6: std::rt::lang_start::{{closure}}
   7: std::rt::lang_start_internal
   8: main
   9: __libc_start_call_main
             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  10: __libc_start_main_impl
             at ./csu/../csu/libc-start.c:360:3
  11: _start
```

I was able to inspect some of the generates source files, which looked fine though. The implementation is based on the one added in https://github.com/rust-embedded/svd2rust/pull/959